### PR TITLE
refactor: dependency inject quest db

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -24,7 +24,8 @@ config :point_quest, PointQuestWeb.Endpoint,
 config :point_quest, PointQuest.Behaviour.Linear, PointQuest.Linear
 config :point_quest, PointQuest.Behaviour.Linear.Client, PointQuest.Linear.Client
 config :point_quest, PointQuest.Behaviour.Linear.Repo, PointQuest.Linear.Repo
-config :point_quest, PointQuest.Behaviour.Quest, PointQuest.Quests
+config :point_quest, PointQuest.Behaviour.Quests, PointQuest.Quests
+config :point_quest, PointQuest.Behaviour.Quests.Repo, Infra.Quests.Db
 config :point_quest, PointQuest.Behaviour.Ticket, Infra.Linear.Linear
 
 # Configures the mailer

--- a/lib/infra/quests/db.ex
+++ b/lib/infra/quests/db.ex
@@ -2,9 +2,9 @@ defmodule Infra.Quests.Db do
   @moduledoc """
   In-memory DB system
   """
-  alias PointQuest.Quests.Quest
+  @behaviour PointQuest.Behaviour.Quests.Repo
 
-  @spec create(Ecto.Changeset.t(Quest.t())) :: {:ok, Quest.t()} | {:error, Ecto.Changeset.t()}
+  @impl PointQuest.Behaviour.Quests.Repo
   def create(quest_changeset) do
     with {:ok, quest} <- Ecto.Changeset.apply_action(quest_changeset, :insert) do
       quest = Map.put(quest, :id, Ecto.UUID.generate())
@@ -13,7 +13,7 @@ defmodule Infra.Quests.Db do
     end
   end
 
-  @spec update(Ecto.Changeset.t(Quest.t())) :: {:ok, Quest.t()}
+  @impl PointQuest.Behaviour.Quests.Repo
   def update(quest_changeset) do
     with {:ok, quest} <- Ecto.Changeset.apply_action(quest_changeset, :update) do
       server = lookup_quest_server(quest.id)
@@ -22,7 +22,7 @@ defmodule Infra.Quests.Db do
     end
   end
 
-  @spec get_quest_by_id(quest_id :: String.t()) :: {:ok, Quest.t()} | {:error, :quest_not_found}
+  @impl PointQuest.Behaviour.Quests.Repo
   def get_quest_by_id(quest_id) do
     case lookup_quest_server(quest_id) do
       nil ->
@@ -33,7 +33,6 @@ defmodule Infra.Quests.Db do
     end
   end
 
-  @spec lookup_quest_server(quest_id :: String.t()) :: pid() | nil
   defp lookup_quest_server(quest_id) do
     case Registry.lookup(Infra.Quests.Registry, quest_id) do
       [{pid, _state}] ->

--- a/lib/point_quest.ex
+++ b/lib/point_quest.ex
@@ -8,6 +8,6 @@ defmodule PointQuest do
   """
 
   @spec quest_service() :: module()
-  def quest_service(), do: Application.get_env(:point_quest, PointQuest.Behaviour.Quest)
+  def quest_service(), do: Application.get_env(:point_quest, PointQuest.Behaviour.Quests)
   def ticket_service(), do: Application.get_env(:point_quest, PointQuest.Behaviour.Ticket)
 end

--- a/lib/point_quest/behaviour/quests/repo.ex
+++ b/lib/point_quest/behaviour/quests/repo.ex
@@ -1,0 +1,9 @@
+defmodule PointQuest.Behaviour.Quests.Repo do
+  alias Ecto.Changeset
+  alias PointQuest.Quests.Quest
+
+  @callback create(Ecto.Changeset.t(Quest.t())) :: {:ok, Quest.t()} | {:error, Changeset.t()}
+  @callback update(Ecto.Changeset.t(Quest.t())) :: {:ok, Quest.t()}
+  @callback get_quest_by_id(quest_id :: String.t()) ::
+              {:ok, Quest.t()} | {:error, :quest_not_found}
+end

--- a/lib/point_quest/quests.ex
+++ b/lib/point_quest/quests.ex
@@ -6,23 +6,25 @@ defmodule PointQuest.Quests do
 
   alias PointQuest.Quests.Quest
 
+  defp repo(), do: Application.get_env(:point_quest, PointQuest.Behaviour.Quests.Repo)
+
   @impl PointQuest.Behaviour.Quest
   def create(quest_params) do
     %Quest{}
     |> Quest.create_changeset(quest_params)
-    |> Infra.Quests.Db.create()
+    |> repo().create()
   end
 
   @impl PointQuest.Behaviour.Quest
   def get(quest_id) do
-    Infra.Quests.Db.get_quest_by_id(quest_id)
+    repo().get_quest_by_id(quest_id)
   end
 
   @impl PointQuest.Behaviour.Quest
   def add_adventurer_to_party(quest_id, adventurer_params) do
     with {:ok, quest} <- Infra.Quests.Db.get_quest_by_id(quest_id) do
       Quest.add_adventurer_to_party_changeset(quest, adventurer_params)
-      |> Infra.Quests.Db.update()
+      |> repo().update()
     end
   end
 end


### PR DESCRIPTION
This gives us a path to test out other implementations or to switch what we test with for the quest database. Also cleaned up one of the other dependency injected modules whose name was wrong.

Closes: PD-27