### PR TITLE
feat: quest server implements kill timeout

### DIFF
--- a/lib/infra/quests/quest_server.ex
+++ b/lib/infra/quests/quest_server.ex
@@ -3,9 +3,56 @@ defmodule Infra.Quests.QuestServer do
   Agent to hold quest state
   """
 
-  use Agent
+  use GenServer, restart: :transient
 
-  def start_link(quest) do
-    Agent.start_link(fn -> quest end, name: {:via, Registry, {Infra.Quests.Registry, quest.id}})
+  def start_link(opts) do
+    opts =
+      opts
+      |> Keyword.take([:quest, :timeout])
+      |> Keyword.put_new(:timeout, :timer.hours(1))
+      |> Map.new()
+
+    GenServer.start_link(__MODULE__, opts,
+      name: {:via, Registry, {Infra.Quests.Registry, opts.quest.id}}
+    )
+  end
+
+  def update(server, quest) do
+    GenServer.call(server, {:update_quest, quest})
+  end
+
+  def get(server) do
+    GenServer.call(server, {:fetch_quest})
+  end
+
+  def init(%{quest: _quest, timeout: timeout} = opts) do
+    timeout_ref = schedule_cleanup(timeout)
+    state = Map.put(opts, :timeout_ref, timeout_ref)
+
+    {:ok, state}
+  end
+
+  def handle_call({:update_quest, quest}, _from, state) do
+    :erlang.cancel_timer(state.timeout_ref)
+
+    state = %{
+      state
+      | timeout_ref: schedule_cleanup(state.timeout),
+        quest: quest
+    }
+
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:fetch_quest}, _from, state) do
+    {:reply, state.quest, state}
+  end
+
+  def handle_info(:kill, _state) do
+    Process.exit(self(), :shutdown)
+  end
+
+  defp schedule_cleanup(timeout) do
+    Process.send_after(self(), :kill, timeout)
   end
 end

--- a/test/infra/quests/quest_server_test.exs
+++ b/test/infra/quests/quest_server_test.exs
@@ -1,0 +1,38 @@
+defmodule Infra.Quests.QuestServerTest do
+  use ExUnit.Case, async: true
+
+  alias Infra.Quests.QuestServer
+  alias PointQuest.Quests.Quest
+
+  describe "automatic cleanup of old sessions" do
+    setup do
+      quest =
+        Quest.create_changeset(%Quest{}, %{name: "Bob's Burgers", party_leader: %{name: "Bob"}})
+        |> Ecto.Changeset.apply_action!(:insert)
+
+      Process.flag(:trap_exit, true)
+
+      {:ok, quest_server} = QuestServer.start_link(quest: quest, timeout: 500)
+
+      {:ok, quest: quest, quest_server: quest_server}
+    end
+
+    test "quest dies after timeout", %{quest_server: quest_server} do
+      assert_receive({:EXIT, ^quest_server, :shutdown}, 1000)
+    end
+
+    test "update prolongs life of quest", %{quest: quest, quest_server: quest_server} do
+      # sending the same quest, server don't care
+      Process.sleep(250)
+      QuestServer.update(quest_server, quest)
+      Process.sleep(250)
+      QuestServer.update(quest_server, quest)
+
+      # we're over the 500ms initial kill timeout
+      refute_receive({:EXIT, ^quest_server, :shutdown}, 100)
+
+      # should now be receiving the kill timeout
+      assert_receive({:EXIT, ^quest_server, :shutdown}, 500)
+    end
+  end
+end


### PR DESCRIPTION
Quest server converted to GenServer, and now implements a timeout to clean itself up after a set duration.