### PR TITLE
feat: include cycles in linear schema

### DIFF
--- a/lib/infra/linear/records/cycle.ex
+++ b/lib/infra/linear/records/cycle.ex
@@ -1,0 +1,19 @@
+defmodule Infra.Linear.Records.Cycle do
+  @moduledoc """
+  A linear cycle, used to constrain the current sprint of work.
+  """
+
+  use Infra.LinearObject
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          name: String.t(),
+          number: Float.t()
+        }
+
+  object do
+    field :id, :string
+    field :name, :string
+    field :number, :float
+  end
+end

--- a/lib/infra/linear/records/issue.ex
+++ b/lib/infra/linear/records/issue.ex
@@ -6,6 +6,7 @@ defmodule Infra.Linear.Records.Issue do
   use Infra.LinearObject
 
   alias Infra.Linear.Records.Comment
+  alias Infra.Linear.Records.Cycle
   alias Infra.Linear.Records.Project
   alias Infra.Linear.Records.WorkflowState
   alias Infra.Linear.Records.User
@@ -14,7 +15,6 @@ defmodule Infra.Linear.Records.Issue do
   # attachments (linked issues?): [Issue]
   # boardOrder
   # children: [Issue]
-  # cycle: Cycle TODO: PQ-4
   # dueDate: DateTime (although says timeless?)
   # history: IssueHistoryConnection TODO: PQ-5
   # identifier: human readable id string
@@ -33,6 +33,7 @@ defmodule Infra.Linear.Records.Issue do
           comments: [Comment.t()],
           createdAt: DateTime.t(),
           creator: User.t(),
+          cycle: Cycle.t(),
           description: String.t(),
           estimate: Float.t(),
           priority: Float.t(),
@@ -49,6 +50,7 @@ defmodule Infra.Linear.Records.Issue do
     nodes(:comments, Comment)
     field :createdAt, :utc_datetime
     embed(:creator, User)
+    embed(:cycle, Cycle)
     field :description, :string
     field :estimate, :float
     field :priority, :float

--- a/lib/queries/graphql/issues_snippet.graphql.eex
+++ b/lib/queries/graphql/issues_snippet.graphql.eex
@@ -28,6 +28,11 @@ issues {
       url
       avatarUrl
     }
+    cycle {
+      id
+      name
+      number
+    }
     estimate
     state {
       id


### PR DESCRIPTION
References `Cycle` in Linear issues.

Creates `Cycle` data model.

References `Cycle` in `Issue` GraphQL snippet.

Fixes PQ-4