### PR TITLE
fix: use t() types instead of named types

### DIFF
--- a/lib/infra/linear/records/comment.ex
+++ b/lib/infra/linear/records/comment.ex
@@ -7,7 +7,7 @@ defmodule Infra.Linear.Records.Comment do
 
   alias Infra.Linear.Records.User
 
-  @type comment :: %__MODULE__{
+  @type t :: %__MODULE__{
           id: String.t(),
           body: String.t(),
           createdAt: DateTime.t(),

--- a/lib/infra/linear/records/issue.ex
+++ b/lib/infra/linear/records/issue.ex
@@ -37,7 +37,7 @@ defmodule Infra.Linear.Records.Issue do
           description: String.t(),
           estimate: Float.t(),
           priority: Float.t(),
-          project: Project.project(),
+          project: Project.t(),
           state: WorkflowState.issue_status(),
           title: String.t(),
           url: String.t()

--- a/lib/infra/linear/records/project.ex
+++ b/lib/infra/linear/records/project.ex
@@ -5,7 +5,7 @@ defmodule Infra.Linear.Records.Project do
 
   use Infra.LinearObject
 
-  @type project :: %__MODULE__{
+  @type t :: %__MODULE__{
           id: String.t(),
           name: String.t()
         }

--- a/lib/infra/linear/records/user.ex
+++ b/lib/infra/linear/records/user.ex
@@ -5,7 +5,7 @@ defmodule Infra.Linear.Records.User do
 
   use Infra.LinearObject
 
-  @type user :: %__MODULE__{
+  @type t :: %__MODULE__{
           id: String.t(),
           avatarUrl: String.t(),
           displayName: String.t(),

--- a/lib/infra/linear/records/workflow_state.ex
+++ b/lib/infra/linear/records/workflow_state.ex
@@ -9,13 +9,6 @@ defmodule Infra.Linear.Records.WorkflowState do
 
   alias Infra.Linear.Records.Issue
 
-  @type t :: %__MODULE__{
-          id: String.t(),
-          issues: [Issue.t()] | nil,
-          name: String.t(),
-          position: Float.t()
-        }
-
   @type issue_status :: %__MODULE__{
           id: String.t(),
           issues: nil,
@@ -29,6 +22,8 @@ defmodule Infra.Linear.Records.WorkflowState do
           name: String.t(),
           position: Float.t()
         }
+
+  @type t :: issue_status | queried_workflow_state
 
   object do
     field :id, :string


### PR DESCRIPTION
There were several instances of Linear records using a named type for their struct definition (i.e., `Comments` struct typing was `comment`, referenced as `Comments.comment()` instead of `Comments.t()`). Updated any current instance of this I could find to use `t()` typing unless there was a valid reason to have a named type.

Workflow state is the only current instance that has two named types, as there is the concept of just listing the state that an issue is in, as well as being able to retrieve a list of issues based on a workflow state id. The `t()` type for Workflow State is the union of these two named types.