### PR TITLE
feat: include labels in linear schema

### DIFF
--- a/lib/infra/linear/records/issue.ex
+++ b/lib/infra/linear/records/issue.ex
@@ -19,7 +19,6 @@ defmodule Infra.Linear.Records.Issue do
   # history: IssueHistoryConnection TODO: PQ-5
   # identifier: human readable id string
   # inverseRelations: IssueRelationConnection TODO: PQ-6
-  # labels: IssueLabelConnection TODO: PQ-7
   # parent: Issue
   # priorityLabel (maybe?): String
   # projectMilestones: ProjectMilestones TODO: PQ-9

--- a/lib/infra/linear/records/label.ex
+++ b/lib/infra/linear/records/label.ex
@@ -1,0 +1,17 @@
+defmodule Infra.Linear.Records.Label do
+  @moduledoc """
+  A linear label, used to group similar issues.
+  """
+
+  use Infra.LinearObject
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          name: String.t()
+        }
+
+  object do
+    field :id, :string
+    field :name, :string
+  end
+end


### PR DESCRIPTION
Creates a `Label` linear record.

Removes label-related TODO from issue.

**Note:** Label was not included when fetching the list of issues for a team, as we have reached the complexity limit of Linear graphql queries.