### PR TITLE
refactor: use slim issues query

### DIFF
--- a/lib/infra/linear/records/field.ex
+++ b/lib/infra/linear/records/field.ex
@@ -1,0 +1,37 @@
+defmodule Infra.Linear.Records.Field do
+  @moduledoc """
+  Handles cases where the underlying ecto type was not loaded in the query
+  """
+
+  use Ecto.ParameterizedType
+
+  @impl Ecto.ParameterizedType
+  def type(params) do
+    params.type
+  end
+
+  @impl Ecto.ParameterizedType
+  def init(opts) do
+    # throw if type not present, TODO validate schema
+    Map.new(opts)
+  end
+
+  @impl Ecto.ParameterizedType
+  def load(data, _loader, _params) do
+    # this doesn't actually matter with our model
+    {:ok, data}
+  end
+
+  @impl Ecto.ParameterizedType
+  def dump(data, _dumper, _params) do
+    # also don't care
+    {:ok, data}
+  end
+
+  @impl Ecto.ParameterizedType
+  def cast(:not_loaded, _params), do: {:ok, :not_loaded}
+
+  def cast(data, params) do
+    Ecto.Type.cast(params.type, data)
+  end
+end

--- a/lib/infra/linear/records/issue.ex
+++ b/lib/infra/linear/records/issue.ex
@@ -7,6 +7,7 @@ defmodule Infra.Linear.Records.Issue do
 
   alias Infra.Linear.Records.Comment
   alias Infra.Linear.Records.Cycle
+  alias Infra.Linear.Records.Label
   alias Infra.Linear.Records.Project
   alias Infra.Linear.Records.WorkflowState
   alias Infra.Linear.Records.User
@@ -25,7 +26,7 @@ defmodule Infra.Linear.Records.Issue do
   # relations: IssueRelationConnection
   # sortOrder: Float
 
-  @type issue :: %__MODULE__{
+  @type full_issue :: %__MODULE__{
           id: String.t(),
           identifier: String.t(),
           branchName: String.t(),
@@ -35,12 +36,21 @@ defmodule Infra.Linear.Records.Issue do
           cycle: Cycle.t(),
           description: String.t(),
           estimate: Float.t(),
+          labels: [Label.t()],
           priority: Float.t(),
           project: Project.t(),
           state: WorkflowState.issue_status(),
           title: String.t(),
           url: String.t()
         }
+
+  @type issue_card :: %__MODULE__{
+          id: String.t(),
+          identifier: String.t(),
+          title: String.t()
+        }
+
+  @type t :: full_issue | issue_card
 
   object do
     field :id, :string
@@ -52,6 +62,7 @@ defmodule Infra.Linear.Records.Issue do
     embed(:cycle, Cycle)
     field :description, :string
     field :estimate, :float
+    nodes(:labels, Label)
     field :priority, :float
     embed(:project, Project)
     embed(:state, WorkflowState)

--- a/lib/infra/linear_object.ex
+++ b/lib/infra/linear_object.ex
@@ -55,8 +55,8 @@ defmodule Infra.LinearObject do
       LinearObject.__define_field__(
         __MODULE__,
         :field,
-        {unquote(name), unquote(type)},
-        unquote(opts)
+        {unquote(name), Infra.Linear.Records.Field},
+        unquote(opts) ++ [type: unquote(type)]
       )
     end
   end
@@ -116,6 +116,8 @@ defmodule Infra.LinearObject do
 
   @spec load(module(), nil) :: nil
   def load(_object, nil), do: nil
+
+  def load(_object, :not_loaded), do: :not_loaded
 
   @spec load(module(), map()) :: struct()
   def load(object, data) do
@@ -229,6 +231,8 @@ defmodule Infra.LinearObject do
     get(Map.get(record, key), rest)
   end
 
+  defp load_nodes(_params, :not_loaded), do: :not_loaded
+
   defp load_nodes(node, params) do
     params = get_key(params, :nodes)
     load(node, params)
@@ -240,8 +244,10 @@ defmodule Infra.LinearObject do
 
   defp composite?(_type), do: false
 
+  # defp get_key(:not_loaded, _key), do: :not_loaded
+
   defp get_key(map, atom_key) do
     # try to get key as atom and fall back to string version
-    Map.get(map, atom_key, Map.get(map, Atom.to_string(atom_key)))
+    Map.get(map, atom_key, Map.get(map, Atom.to_string(atom_key), :not_loaded))
   end
 end

--- a/lib/point_quest/linear.ex
+++ b/lib/point_quest/linear.ex
@@ -36,7 +36,7 @@ defmodule PointQuest.Linear do
 
   @impl PointQuest.Behaviour.Linear
   def list_issues(team_id, user_id) do
-    issues_snippet = QueryParser.issues_snippet([])
+    issues_snippet = QueryParser.issues_snippet_slim([])
     body = %{query: QueryParser.list_issues_for_team(id: team_id, issues_snippet: issues_snippet)}
 
     {:ok, %Tesla.Env{body: %{"data" => %{"team" => team}}}} =

--- a/lib/point_quest_web/live/components/list.ex
+++ b/lib/point_quest_web/live/components/list.ex
@@ -1,4 +1,8 @@
 defmodule PointQuestWeb.Live.Components.List do
+  @moduledoc """
+  A component handling display of a sortable list of Linear issues
+  """
+
   use PointQuestWeb, :live_component
 
   def render(assigns) do

--- a/lib/queries/graphql/issues_snippet_slim.graphql.eex
+++ b/lib/queries/graphql/issues_snippet_slim.graphql.eex
@@ -1,0 +1,7 @@
+issues {
+  nodes {
+    id
+    identifier
+    title
+  }
+}


### PR DESCRIPTION
Handle the use case where our graphql query may not be returning a fully shaped object as defined in the issue schema, but rather a slimly typed shape only containing fields needed for title cards.