### PR TITLE
Jasonnoonan/pq 42

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -14,7 +14,7 @@ config :point_quest, PointQuestWeb.Endpoint,
     formats: [html: PointQuestWeb.ErrorHTML, json: PointQuestWeb.ErrorJSON],
     layout: false
   ],
-  pubsub_server: PointQuest.PubSub,
+  pubsub_server: PointQuestWeb.PubSub,
   live_view: [signing_salt: "Qx76kENh"]
 
 # Configures dependency injection

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -9,7 +9,7 @@ import Config
 config :point_quest, PointQuestWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
-  http: [ip: {127, 0, 0, 1}, port: 4000],
+  http: [ip: {0, 0, 0, 0}, port: 4000],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,

--- a/lib/point_quest/application.ex
+++ b/lib/point_quest/application.ex
@@ -15,7 +15,8 @@ defmodule PointQuest.Application do
       # Registry for managing quest processes
       {Registry, keys: :unique, name: Infra.Quests.Registry},
       # Start the PubSub system
-      {Phoenix.PubSub, name: PointQuest.PubSub},
+      {Phoenix.PubSub, name: PointQuestWeb.PubSub},
+      PointQuestWeb.Presence,
       # Start Finch
       {Finch, name: PointQuest.Finch},
       # Start the Endpoint (http/https)

--- a/lib/point_quest_web/live/quest_join.ex
+++ b/lib/point_quest_web/live/quest_join.ex
@@ -1,0 +1,76 @@
+defmodule PointQuestWeb.QuestJoinLive do
+  use PointQuestWeb, :live_view
+
+  alias PointQuest.Quests.Commands.AddAdventurer
+
+  def render(assigns) do
+    ~H"""
+    <.form
+      for={@form}
+      id="join-quest-form"
+      phx-change="validate_adventurer"
+      phx-debounce="250"
+      phx-submit="join_party"
+    >
+      <.input type="text" field={@form[:name]} label="Adventurer Name" />
+      <.input type="select" field={@form[:class]} label="Class" options={@classes} />
+      <.button type="submit" disabled={not @form.source.valid?}>Join Quest</.button>
+    </.form>
+    """
+  end
+
+  def mount(params, _session, socket) do
+    socket =
+      case Infra.Quests.Db.get_quest_by_id(params["id"]) do
+        {:ok, quest} ->
+          changeset = get_changeset(%{quest_id: quest.id})
+          classes = PointQuest.Quests.Adventurer.Class.NameEnum.valid_atoms()
+
+          socket
+          |> assign(classes: classes, form: to_form(changeset), quest: quest)
+
+        {:error, :quest_not_found} ->
+          redirect(socket, to: ~p"/quest")
+      end
+
+    {:ok, socket}
+  end
+
+  def handle_event("validate_adventurer", %{"add_adventurer" => params}, socket) do
+    params = Map.put(params, "quest_id", socket.assigns.quest.id)
+
+    form =
+      params
+      |> get_changeset()
+      |> to_form()
+
+    {:noreply, assign(socket, form: form)}
+  end
+
+  def handle_event(
+        "join_party",
+        %{"add_adventurer" => %{"name" => name, "class" => class}},
+        socket
+      ) do
+    {:ok, quest} =
+      %{quest_id: socket.assigns.quest.id, name: name, class: class}
+      |> AddAdventurer.new!()
+      |> AddAdventurer.execute()
+
+    adventurer = Enum.find(quest.adventurers, fn a -> a.name == name end)
+
+    token =
+      adventurer
+      |> PointQuest.Authentication.create_actor()
+      |> PointQuest.Authentication.actor_to_token()
+
+    {:noreply, push_navigate(socket, to: ~p"/switch/#{token}")}
+  end
+
+  defp get_changeset(params) do
+    case AddAdventurer.new(params) do
+      {:ok, %AddAdventurer{} = command} -> AddAdventurer.changeset(command, %{})
+      {:error, changeset} -> changeset
+    end
+  end
+end

--- a/lib/point_quest_web/middleware/load_actor.ex
+++ b/lib/point_quest_web/middleware/load_actor.ex
@@ -1,0 +1,51 @@
+defmodule PointQuestWeb.Middleware.LoadActor.Plug do
+  @moduledoc """
+  Attempts to load an actor from the Phoenix Session.
+  """
+  import Plug.Conn
+
+  require Logger
+
+  @spec init(keyword()) :: keyword()
+  def init(config), do: config
+
+  @spec call(Plug.Conn.t(), keyword()) :: Plug.Conn.t()
+  def call(conn, _opts) do
+    Logger.info("Loading Actor from Phoenix Session")
+
+    actor =
+      with session_token when is_binary(session_token) <- get_session(conn, "session_token"),
+           {:ok, actor} <- PointQuest.Authentication.token_to_actor(session_token) do
+        actor
+      else
+        _no_session ->
+          Logger.info("Unable to load Actor, continuing with no session")
+          nil
+      end
+
+    assign(conn, :current_actor, actor)
+  end
+end
+
+defmodule PointQuestWeb.Middleware.LoadActor.Hook do
+  import Phoenix.Component
+  require Logger
+
+  @spec on_mount(atom(), map(), map(), Phoenix.LiveView.Socket.t()) ::
+          {atom(), Phoenix.LiveView.Socket.t()}
+  def on_mount(:default, _params, phoenix_session, socket) do
+    Logger.info("Loading Actor from Phoenix Session")
+
+    actor =
+      with session_token when is_binary(session_token) <- phoenix_session["session"],
+           {:ok, actor} <- PointQuest.Authentication.token_to_actor(session_token) do
+        actor
+      else
+        _no_session ->
+          Logger.info("Unable to load Actor, continuing with no session")
+          nil
+      end
+
+    {:cont, assign(socket, :current_actor, actor)}
+  end
+end

--- a/lib/point_quest_web/presence.ex
+++ b/lib/point_quest_web/presence.ex
@@ -1,0 +1,3 @@
+defmodule PointQuestWeb.Presence do
+  use Phoenix.Presence, otp_app: :point_quest, pubsub_server: PointQuestWeb.PubSub
+end


### PR DESCRIPTION
added a LoadActor plug (which I'm not sure is working? I basically just stole the logic from Portal but I don't see the current_session key in the session anywhere downstream like liveview mount.)

moved the quest/:id/join logic to a separate liveview and put /quest/:id behind a pipeline utlizing LoadActor.