### PR TITLE
feat: redirect joins that are already in the quest

### DIFF
--- a/lib/point_quest_web/live/quest.ex
+++ b/lib/point_quest_web/live/quest.ex
@@ -62,15 +62,23 @@ defmodule PointQuestWeb.QuestLive do
     end)
   end
 
-  defp actor_to_meta(%PointQuest.Authentication.Actor.PartyLeader{quest_id: quest_id, leader_id: user_id, adventurer: nil}) do
+  defp actor_to_meta(%PointQuest.Authentication.Actor.PartyLeader{
+         leader_id: user_id,
+         adventurer: nil
+       }) do
     %{user_id: user_id, class: "leader", name: "Party Leader"}
   end
 
-  defp actor_to_meta(%PointQuest.Authentication.Actor.PartyLeader{leader_id: user_id, adventurer: adventurer}) do
+  defp actor_to_meta(%PointQuest.Authentication.Actor.PartyLeader{
+         leader_id: user_id,
+         adventurer: adventurer
+       }) do
     %{user_id: user_id, class: adventurer.class, name: adventurer.name}
   end
 
-  defp actor_to_meta(%PointQuest.Authentication.Actor.Adventurer{adventurer: %{id: user_id} = adventurer}) do
+  defp actor_to_meta(%PointQuest.Authentication.Actor.Adventurer{
+         adventurer: %{id: user_id} = adventurer
+       }) do
     %{user_id: user_id, class: adventurer.class, name: adventurer.name}
   end
 end

--- a/lib/point_quest_web/router.ex
+++ b/lib/point_quest_web/router.ex
@@ -49,20 +49,15 @@ defmodule PointQuestWeb.Router do
     end
   end
 
-  scope "/", PointQuestWeb do
-    pipe_through [:browser]
-
-    get "/switch/:token", Switch, :set_session
-
-    live "/quest", QuestStartLive
-    live "/quest/:id/join", QuestJoinLive
-  end
-
   live_session :ensure_actor, on_mount: [PointQuestWeb.Middleware.LoadActor.Hook] do
     pipe_through [:browser]
 
     scope "/", PointQuestWeb do
+      get "/switch/:token", Switch, :set_session
       live "/quest/:id", QuestLive
+
+    live "/quest", QuestStartLive
+    live "/quest/:id/join", QuestJoinLive
     end
   end
 end


### PR DESCRIPTION
When hitting the quest join view to join a quest that exists and the current session is already involved in this will now redirect the user to the quest view.

Closes: PQ-57