### PR TITLE
feat: add attack command and event

### DIFF
--- a/lib/infra/quests/db.ex
+++ b/lib/infra/quests/db.ex
@@ -23,7 +23,7 @@ defmodule Infra.Quests.Db do
     {:ok, new_quest}
   end
 
-  def write(quest, %Event.AdventurerJoinedParty{} = event) do
+  def write(quest, event) do
     new_quest = Quest.project(event, quest)
 
     server = lookup_quest_server(new_quest.id)

--- a/lib/point_quest/quests/attack.ex
+++ b/lib/point_quest/quests/attack.ex
@@ -2,15 +2,15 @@ defmodule PointQuest.Quests.Attack do
   @moduledoc """
   An attack an adventurer makes against the current ticket
   """
-
   use Ecto.Schema
-
   import Ecto.Changeset
+
+  alias PointQuest.Quests
 
   @primary_key false
   embedded_schema do
     field :adventurer_id, :string
-    field :attack, :integer
+    field :attack, Quests.AttackValue
   end
 
   def create_changeset(attack, params \\ %{}) do

--- a/lib/point_quest/quests/attack_value.ex
+++ b/lib/point_quest/quests/attack_value.ex
@@ -1,0 +1,26 @@
+defmodule PointQuest.Quests.AttackValue do
+  use Ecto.Type
+
+  @type t :: non_neg_integer()
+
+  @valid_attacks [0, 1, 2, 3, 5, 8, 13]
+
+  @impl Ecto.Type
+  def type(), do: :integer
+
+  @impl Ecto.Type
+  def cast(attack_value) when attack_value in @valid_attacks do
+    {:ok, attack_value}
+  end
+
+  @impl Ecto.Type
+  def cast(_invalid_attack) do
+    {:error, "invalid attack value"}
+  end
+
+  @impl Ecto.Type
+  def load(attack_value), do: {:ok, attack_value}
+
+  @impl Ecto.Type
+  def dump(attack_value), do: {:ok, attack_value}
+end

--- a/lib/point_quest/quests/commands/attack.ex
+++ b/lib/point_quest/quests/commands/attack.ex
@@ -1,0 +1,49 @@
+defmodule PointQuest.Quests.Commands.Attack do
+  @moduledoc """
+  Command for an adventure to attack for round in a quest.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias PointQuest.Quests
+
+  @type t :: %__MODULE__{
+          quest_id: String.t(),
+          adventurer_id: String.t(),
+          attack: AttackValue.t()
+        }
+
+  defp repo(), do: Application.get_env(:point_quest, PointQuest.Behaviour.Quests.Repo)
+
+  @primary_key false
+  embedded_schema do
+    field :quest_id, :string
+    field :adventurer_id, :string
+    field :attack, Quests.AttackValue
+  end
+
+  @spec changeset(t(), map()) :: Ecto.Changeset.t(t())
+  def changeset(attack, params \\ %{}) do
+    attack
+    |> cast(params, [:quest_id, :adventurer_id, :attack])
+    |> validate_required([:quest_id, :adventurer_id, :attack])
+  end
+
+  def new!(params) do
+    %__MODULE__{}
+    |> changeset(params)
+    |> apply_action!(:update)
+  end
+
+  def new(params) do
+    %__MODULE__{}
+    |> changeset(params)
+    |> apply_action(:update)
+  end
+
+  def execute(%__MODULE__{quest_id: quest_id} = attack_command) do
+    with {:ok, quest} <- repo().get_quest_by_id(quest_id),
+         {:ok, event} <- Quests.Quest.handle(attack_command, quest) do
+      repo().write(quest, event)
+    end
+  end
+end

--- a/lib/point_quest/quests/events/adventurer_attacked.ex
+++ b/lib/point_quest/quests/events/adventurer_attacked.ex
@@ -1,0 +1,25 @@
+defmodule PointQuest.Quests.Event.AdventurerAttacked do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias PointQuest.Quests.AttackValue
+
+  @primary_key false
+  embedded_schema do
+    field :quest_id, :string
+    field :adventurer_id, :string
+    field :attack, AttackValue
+  end
+
+  def new!(params) do
+    %__MODULE__{}
+    |> changeset(params)
+    |> apply_action!(:insert)
+  end
+
+  def changeset(adventurer_attacked, params \\ %{}) do
+    adventurer_attacked
+    |> cast(params, [:quest_id, :adventurer_id, :attack])
+    |> validate_required([:quest_id, :adventurer_id, :attack])
+  end
+end


### PR DESCRIPTION
This command sets up users being able to do initial attacks as well as additional attacks for the round.

Closes: PQ-58