### PR TITLE
refactor: change current_actor to actor

### DIFF
--- a/lib/point_quest_web/live/quest.ex
+++ b/lib/point_quest_web/live/quest.ex
@@ -12,7 +12,7 @@ defmodule PointQuestWeb.QuestLive do
   def render(assigns) do
     ~H"""
     <div class="flex flex-col w-full">
-      <div :if={is_party_leader?(@current_actor)} id="leader-controls" class="flex justify-between">
+      <div :if={is_party_leader?(@actor)} id="leader-controls" class="flex justify-between">
         <div id="quest-actions">
           <.button phx-click="show_attacks">Show Attacks</.button>
           <.button phx-click="clear_attacks">Clear Attacks</.button>
@@ -40,7 +40,7 @@ defmodule PointQuestWeb.QuestLive do
     socket =
       case Infra.Quests.Db.get_quest_by_id(params["id"]) do
         {:ok, quest} ->
-          user_meta = actor_to_meta(socket.assigns.current_actor)
+          user_meta = actor_to_meta(socket.assigns.actor)
           PointQuestWeb.Presence.track(self(), quest.id, user_meta.user_id, user_meta)
           Phoenix.PubSub.subscribe(PointQuestWeb.PubSub, quest.id)
 

--- a/lib/point_quest_web/live/quest_join.ex
+++ b/lib/point_quest_web/live/quest_join.ex
@@ -23,7 +23,7 @@ defmodule PointQuestWeb.QuestJoinLive do
   def mount(params, _session, socket) do
     socket =
       with {:ok, quest} <- Infra.Quests.Db.get_quest_by_id(params["id"]),
-           {:in_quest?, false} <- check_actor_in_quest(quest, socket.assigns.current_actor) do
+           {:in_quest?, false} <- check_actor_in_quest(quest, socket.assigns.actor) do
         changeset = get_changeset(%{quest_id: quest.id})
         classes = PointQuest.Quests.Adventurer.Class.NameEnum.valid_atoms()
 

--- a/lib/point_quest_web/middleware/load_actor.ex
+++ b/lib/point_quest_web/middleware/load_actor.ex
@@ -23,7 +23,7 @@ defmodule PointQuestWeb.Middleware.LoadActor.Plug do
           nil
       end
 
-    assign(conn, :current_actor, actor)
+    assign(conn, :actor, actor)
   end
 end
 
@@ -46,6 +46,6 @@ defmodule PointQuestWeb.Middleware.LoadActor.Hook do
           nil
       end
 
-    {:cont, assign(socket, :current_actor, actor)}
+    {:cont, assign(socket, :actor, actor)}
   end
 end


### PR DESCRIPTION
The name "current_actor" implies the existence of an "old actor" state that does not exist in our app.