### PR TITLE
feat: add toggle for joining quest as adventurer

### DIFF
--- a/lib/point_quest_web/components/core_components.ex
+++ b/lib/point_quest_web/components/core_components.ex
@@ -309,7 +309,7 @@ defmodule PointQuestWeb.CoreComponents do
           name={@name}
           value="true"
           checked={@checked}
-          class="rounded border-zinc-300 text-zinc-900 focus:ring-0"
+          class="rounded border-indigo-300 text-indigo-900 focus:ring-0"
           {@rest}
         />
         <%= @label %>

--- a/lib/point_quest_web/live/quest.ex
+++ b/lib/point_quest_web/live/quest.ex
@@ -58,15 +58,6 @@ defmodule PointQuestWeb.QuestLive do
     {:ok, socket}
   end
 
-  def handle_info(%Phoenix.Socket.Broadcast{event: "presence_diff", payload: diff}, socket) do
-    {
-      :noreply,
-      socket
-      |> handle_leaves(diff.leaves)
-      |> handle_joins(diff.joins)
-    }
-  end
-
   def handle_event("copy_link", _params, socket) do
     quest_id = socket.assigns.quest.id
 
@@ -89,6 +80,15 @@ defmodule PointQuestWeb.QuestLive do
     _quest_id = socket.assigns.quest.id
 
     {:noreply, socket}
+  end
+
+  def handle_info(%Phoenix.Socket.Broadcast{event: "presence_diff", payload: diff}, socket) do
+    {
+      :noreply,
+      socket
+      |> handle_leaves(diff.leaves)
+      |> handle_joins(diff.joins)
+    }
   end
 
   def handle_info(%Event.AdventurerAttacked{adventurer_id: adventurer_id, attack: attack}, socket) do

--- a/lib/point_quest_web/live/quest_start.ex
+++ b/lib/point_quest_web/live/quest_start.ex
@@ -9,10 +9,10 @@ defmodule PointQuestWeb.QuestStartLive do
 
   def render(assigns) do
     ~H"""
-    <.form for={@form} id="start-quest-form" phx-submit="start_quest">
+    <.form for={@form} class="flex flex-col space-y-6" id="start-quest-form" phx-submit="start_quest">
       <.input id="quest_name" type="text" field={@form[:name]} label="Quest Name" />
-      <fieldset class="my-4">
-        <legend class="py-2">Make your adventurer (if you want to also vote)</legend>
+      <.input name={:join_as_adventurer} value={@join_as_adventurer} label="Join quest as an adventurer" type="checkbox"phx-click="toggle_join_as_adventurer" />
+      <fieldset :if={@join_as_adventurer} >
         <.inputs_for :let={adventurer_form} field={@form[:party_leaders_adventurer]}>
           <.input
             id="adventurer_name"
@@ -29,7 +29,9 @@ defmodule PointQuestWeb.QuestStartLive do
           />
         </.inputs_for>
       </fieldset>
-      <.button type="submit">Start Quest</.button>
+      <div>
+        <.button type="submit">Start Quest</.button>
+      </div>
     </.form>
     """
   end
@@ -41,9 +43,18 @@ defmodule PointQuestWeb.QuestStartLive do
     changeset = StartQuest.changeset(start_quest, %{})
 
     socket =
-      assign(socket, start_quest: start_quest, classes: classes, form: to_form(changeset))
+      assign(socket,
+        start_quest: start_quest,
+        classes: classes,
+        form: to_form(changeset),
+        join_as_adventurer: false
+      )
 
     {:ok, socket}
+  end
+
+  def handle_event("toggle_join_as_adventurer", _params, socket) do
+    {:noreply, assign(socket, join_as_adventurer: !socket.assigns.join_as_adventurer)}
   end
 
   def handle_event(


### PR DESCRIPTION
I think the old form would have been confusing and leaders would have
always filled it out and joined the quest. I think this along with a
follow up improvement of a tooltip to clarify what all this means is a
good idea.

Closes: PQ-65