### PR TITLE
refactor: move attack controls to a live component

### DIFF
--- a/lib/point_quest_web/live/components/attack.ex
+++ b/lib/point_quest_web/live/components/attack.ex
@@ -1,0 +1,44 @@
+defmodule PointQuestWeb.Live.Components.Attack do
+  use PointQuestWeb, :live_component
+
+  def render(assigns) do
+    ~H"""
+    <div class="flex flex-row rounded-full pt-2">
+      <button
+        :for={attack <- @attack_list}
+        type="action"
+        phx-click="set_attack"
+        phx-value-attack={attack}
+        phx-target={@myself}
+        class={[
+          "p-4 first:rounded-s-full last:rounded-e-full",
+          get_background_color(attack, @selected_attack)
+        ]}
+      >
+        <%= attack %>
+      </button>
+    </div>
+    """
+  end
+
+  def mount(socket) do
+    attack_list = PointQuest.Quests.AttackValue.valid_attacks()
+
+    {:ok, assign(socket, attack_list: attack_list, selected_attack: nil)}
+  end
+
+  def handle_event("set_attack", params, socket) do
+    attack_value = params["attack"] |> String.to_integer()
+
+    socket =
+      case socket.assigns.selected_attack do
+        ^attack_value -> assign(socket, selected_attack: nil)
+        _else -> assign(socket, selected_attack: attack_value)
+      end
+
+    {:noreply, socket}
+  end
+
+  defp get_background_color(attack, attack), do: "bg-amber-400 hover:bg-amber-500"
+  defp get_background_color(_attack, _selected), do: "bg-indigo-400 hover:bg-indigo-500"
+end


### PR DESCRIPTION
Abstracting the attack controls out into a separate live_component so that the state can be managed outside of the quest view directly.

Hides the attack controls if the user does not have an adventurer.

Uses semantic HTML buttons for the attack selectors instead of divs with button styling.