### PR TITLE
fix: prevent changeset errors from crashing form

### DIFF
--- a/lib/point_quest_web/live/quest_start.ex
+++ b/lib/point_quest_web/live/quest_start.ex
@@ -42,7 +42,7 @@ defmodule PointQuestWeb.QuestStartLive do
         </.inputs_for>
       </fieldset>
       <div>
-        <.button type="submit">Start Quest</.button>
+        <.button type="submit" disabled={not @form.source.valid?}>Start Quest</.button>
       </div>
     </.form>
     """
@@ -51,12 +51,10 @@ defmodule PointQuestWeb.QuestStartLive do
   def mount(_params, _session, socket) do
     classes = PointQuest.Quests.Adventurer.Class.NameEnum.valid_atoms()
 
-    start_quest = StartQuest.new!(%{})
-    changeset = StartQuest.changeset(start_quest, %{})
+    changeset = StartQuest.changeset(%StartQuest{}, %{})
 
     socket =
       assign(socket,
-        start_quest: start_quest,
         classes: classes,
         form: to_form(changeset),
         join_as_adventurer: false


### PR DESCRIPTION
It is normal and valid for the changeset to load up in an error state when first hitting the quest start page. This ensures that errors on the changeset at launch do not crash the liveview.

Also removed dead code as the command on the socket was never being used.