### PR TITLE
refactor: only return events from commands

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,13 +1,13 @@
 alias PointQuest.Quests.Commands
 
-{:ok, jeffs_special_quest} =
+{:ok, jeffs_special_quest_event} =
   Commands.StartQuest.execute(
     Commands.StartQuest.new!(%{
       name: "Just let me have this one"
     })
   )
 
-{:ok, lying_quest_leader} =
+{:ok, lying_quest_leader_event} =
   Commands.StartQuest.execute(
     Commands.StartQuest.new!(%{
       name: "I'm a filthy",
@@ -23,7 +23,7 @@ alias PointQuest.Quests.Commands
     })
   )
 
-{:ok, multi_party_quest, _event} =
+{:ok, multi_party_quest_event} =
   Commands.AddAdventurer.execute(
     Commands.AddAdventurer.new!(%{
       quest_id: multi_party_quest.id,
@@ -32,7 +32,7 @@ alias PointQuest.Quests.Commands
     })
   )
 
-{:ok, multi_party_quest, _event} =
+{:ok, multi_party_quest_event} =
   Commands.AddAdventurer.execute(
     Commands.AddAdventurer.new!(%{
       quest_id: multi_party_quest.id,

--- a/lib/point_quest/quests/commands/add_adventurer.ex
+++ b/lib/point_quest/quests/commands/add_adventurer.ex
@@ -147,15 +147,15 @@ defmodule PointQuest.Quests.Commands.AddAdventurer do
                     context: %{command: add_adventurer_command} do
       with {:ok, quest} <- repo().get_quest_by_id(quest_id),
            {:ok, event} <- Quests.Quest.handle(add_adventurer_command, quest),
-           {:ok, updated_quest} <-
+           {:ok, _quest} <-
              repo().write(
                quest,
                event
              ) do
-        {:ok, updated_quest, event}
+        {:ok, event}
       end
     after
-      {:ok, %Quests.Quest{} = quest, event} -> %{quest: quest, event: event}
+      {:ok, event} -> %{event: event}
       {:error, reason} -> %{error: true, reason: reason}
     end
   end

--- a/lib/point_quest/quests/commands/attack.ex
+++ b/lib/point_quest/quests/commands/attack.ex
@@ -51,8 +51,8 @@ defmodule PointQuest.Quests.Commands.Attack do
       with {:ok, quest} <- repo().get_quest_by_id(quest_id),
            true <- can_attack?(attack_command, actor),
            {:ok, event} <- Quests.Quest.handle(attack_command, quest),
-           {:ok, updated_quest} <- repo().write(quest, event) do
-        {:ok, updated_quest, event}
+           {:ok, _quest} <- repo().write(quest, event) do
+        {:ok, event}
       else
         false ->
           {:error, "attack disallowed"}
@@ -61,7 +61,7 @@ defmodule PointQuest.Quests.Commands.Attack do
           error
       end
     after
-      {:ok, %Quests.Quest{} = quest, event} -> %{quest: quest, event: event}
+      {:ok, event} -> %{event: event}
       {:error, reason} -> %{error: true, reason: reason}
     end
   end

--- a/lib/point_quest_web/live/quest_join.ex
+++ b/lib/point_quest_web/live/quest_join.ex
@@ -1,6 +1,7 @@
 defmodule PointQuestWeb.QuestJoinLive do
   use PointQuestWeb, :live_view
 
+  alias PointQuest.Quests.Commands.GetAdventurer
   alias PointQuest.Quests.Commands.AddAdventurer
   alias PointQuest.Quests.Quest
 
@@ -56,12 +57,15 @@ defmodule PointQuestWeb.QuestJoinLive do
         %{"add_adventurer" => %{"name" => name, "class" => class}},
         socket
       ) do
-    {:ok, quest, _event} =
+    {:ok, adventurer_added} =
       %{quest_id: socket.assigns.quest.id, name: name, class: class}
       |> AddAdventurer.new!()
       |> AddAdventurer.execute()
 
-    adventurer = Enum.find(quest.adventurers, fn a -> a.name == name end)
+    {:ok, adventurer} =
+      %{quest_id: socket.assigns.quest.id, adventurer_id: adventurer_added.id}
+      |> GetAdventurer.new!()
+      |> GetAdventurer.execute()
 
     token =
       adventurer


### PR DESCRIPTION
There was a few places where we were returning the quest state and the event that occurred from executing a command. Doing this means that we are going to make it harder to change our internal model if we need to. As much as possible we should bind to events and keep them as minimal as we can.

Closes: PQ-80