### PR TITLE
feat: redirect requests to / to /quest

### DIFF
--- a/lib/point_quest_web/middleware/quest_forwarder.ex
+++ b/lib/point_quest_web/middleware/quest_forwarder.ex
@@ -1,0 +1,11 @@
+defmodule PointQuestWeb.Middleware.QuestForwarder.Plug do
+  use PointQuestWeb, :controller
+
+  @spec init(any()) :: any()
+  def init(opts), do: opts
+
+  @spec call(Plug.Conn.t(), any()) :: Plug.Conn.t()
+  def call(conn, _opts) do
+    redirect(conn, to: ~p"/quest")
+  end
+end

--- a/lib/point_quest_web/router.ex
+++ b/lib/point_quest_web/router.ex
@@ -42,6 +42,8 @@ defmodule PointQuestWeb.Router do
 
       live "/quest", QuestStartLive
       live "/quest/:id/join", QuestJoinLive
+
+      forward "/", Middleware.QuestForwarder.Plug
     end
   end
 end


### PR DESCRIPTION
Currently this will present the user with the create a new quest form.
We could eventually have the create page be smart enough to recognize if
their current session belongs to an existing quest and offer to navigate
to it.

Created a ticket to address that in PQ-85.

Closes: PQ-82