### PR TITLE
refactor: ensure policy checks are generalized

### DIFF
--- a/lib/point_quest/quests/adventurer.ex
+++ b/lib/point_quest/quests/adventurer.ex
@@ -7,8 +7,6 @@ defmodule PointQuest.Quests.Adventurer do
   import Ecto.Changeset
   import PointQuest.Macros.Enum
 
-  alias PointQuest.Quests.Adventurer
-
   @type t :: %__MODULE__{
           name: String.t(),
           class: Adventurer.Class.NameEnum.t(),

--- a/lib/point_quest/quests/commands/add_adventurer.ex
+++ b/lib/point_quest/quests/commands/add_adventurer.ex
@@ -135,7 +135,7 @@ defmodule PointQuest.Quests.Commands.AddAdventurer do
   @doc """
   Executes the command to update the quest state.
 
-  Returns the updated quest.
+  Returns the event for adding the adventurer.
 
   ```elixir
   command = PointQuest.Quests.Commands.AddAdventurer.new!(%{name: "Stevey Beevey", class: :knight, quest_id: "abcd1234"})

--- a/lib/point_quest/quests/spec.ex
+++ b/lib/point_quest/quests/spec.ex
@@ -1,0 +1,53 @@
+defmodule PointQuest.Quests.Spec do
+  @moduledoc """
+  The specifications for determining and enforcing policies.
+
+  These should be helper predicates that, given specific input, determine if the input
+  meets the required criteria.
+
+  For instance, given an actor and a quest, a spec of `is_in_quest?(actor, quest)` would
+  return true when the quest_id of the actor matches the id of the quest, and false otherwise.
+
+  A client utilizing these specs can then determine if the action is allowed or not based on
+  the outcome of checking the spec.
+  """
+  alias PointQuest.Authentication.Actor
+  alias PointQuest.Quests.Adventurer
+  alias PointQuest.Quests.Quest
+
+  @spec is_attacker?(attacker :: Adventurer.t(), actor :: Actor.t()) :: boolean
+  @doc """
+  Ensure the provided attacker id is the actor
+  """
+  def is_attacker?(_attacker, %Actor.PartyLeader{adventurer: nil}), do: false
+
+  def is_attacker?(%Adventurer{id: attacker_id}, %Actor.PartyLeader{
+        adventurer: %{id: attacker_id}
+      }),
+      do: true
+
+  def is_attacker?(%Adventurer{id: _attacker_id}, %Actor.PartyLeader{
+        adventurer: %{id: _other_adventurer}
+      }),
+      do: false
+
+  def is_attacker?(%Adventurer{id: attacker_id}, %Actor.Adventurer{adventurer: %{id: attacker_id}}),
+      do: true
+
+  def is_attacker?(%Adventurer{id: _attacker_id}, %Actor.Adventurer{
+        adventurer: %{id: _other_adventurer}
+      }),
+      do: false
+
+  def is_attacker?(nil, _actor), do: false
+
+  @spec is_in_party?(quest :: Quest.t(), actor :: Actor.t()) :: boolean
+  @doc """
+  Ensure the actor belongs to the provided party
+  """
+  def is_in_party?(%Quest{id: quest_id}, %Actor.PartyLeader{quest_id: quest_id}), do: true
+  def is_in_party?(%Quest{id: _quest_id}, %Actor.PartyLeader{quest_id: _other_quest}), do: false
+
+  def is_in_party?(%Quest{id: quest_id}, %Actor.Adventurer{quest_id: quest_id}), do: true
+  def is_in_party?(%Quest{id: _quest_id}, %Actor.Adventurer{quest_id: _other_quest}), do: false
+end

--- a/test/point_quest/quests/spec_test.exs
+++ b/test/point_quest/quests/spec_test.exs
@@ -1,0 +1,73 @@
+defmodule PointQuest.Quests.SpecTest do
+  use ExUnit.Case
+
+  alias PointQuest.Quests.Spec
+
+  setup do
+    {:ok, QuestSetupHelper.setup()}
+  end
+
+  describe "is_attacker?/2" do
+    test "policy check succeeds if actor is the attacking adventurer", %{
+      adventurer_actor: adventurer,
+      other_actor: party_leader
+    } do
+      assert Spec.is_attacker?(adventurer.adventurer, adventurer)
+      assert Spec.is_attacker?(party_leader.adventurer, party_leader)
+    end
+
+    test "policy check fails if actor is not attacking adventurer", %{
+      adventurer: adventurer,
+      other_actor: other_actor
+    } do
+      refute Spec.is_attacker?(adventurer, other_actor)
+    end
+
+    test "policy check fails if party leader with no adventurer tries to attack for other adventurer",
+         %{party_leader_actor: actor, adventurer: adventurer} do
+      refute Spec.is_attacker?(adventurer, actor)
+    end
+
+    test "policy check fails if nil adventurer is provided", %{party_leader_actor: actor} do
+      refute Spec.is_attacker?(nil, actor)
+    end
+  end
+
+  describe "is_in_party?/2" do
+    test "policy check succeeds if adventurer is in party", %{
+      quest: quest,
+      adventurer_actor: actor
+    } do
+      assert Spec.is_in_party?(quest, actor)
+    end
+
+    test "policy check succeeds if party leader is in party", %{
+      quest: quest,
+      party_leader_actor: actor
+    } do
+      assert Spec.is_in_party?(quest, actor)
+    end
+
+    test "policy check fails if adventurer is not part of current quest", %{
+      quest: quest,
+      other_actor: actor
+    } do
+      refute Spec.is_in_party?(quest, actor)
+    end
+
+    test "policy check fails if actor is adventurer belonging to a different quest", %{
+      other_quest: quest,
+      adventurer_actor: actor
+    } do
+      refute Spec.is_in_party?(quest, actor)
+    end
+
+    test "policy check fails if actor is an adventurer different from the attacking adventurer",
+         %{
+           other_quest: quest,
+           adventurer_actor: actor
+         } do
+      refute Spec.is_in_party?(quest, actor)
+    end
+  end
+end

--- a/test/support/quest_setup_helper.ex
+++ b/test/support/quest_setup_helper.ex
@@ -1,0 +1,55 @@
+defmodule QuestSetupHelper do
+  @moduledoc """
+  A simple helper for tests requiring quest setup.
+  """
+  alias PointQuest.Quests.Commands.AddAdventurer
+  alias PointQuest.Quests.Commands.GetAdventurer
+  alias PointQuest.Quests.Commands.StartQuest
+
+  def setup() do
+    {:ok, %{party_leader: party_leader} = quest} =
+      StartQuest.new!(%{name: "proper quest"}) |> StartQuest.execute()
+
+    {:ok, other_quest} =
+      StartQuest.new!(%{
+        name: "Steve's Shenanigans",
+        party_leaders_adventurer: %{name: "Stevey Beevey", class: :mage}
+      })
+      |> StartQuest.execute()
+
+    {:ok, %{id: adventurer_id}} =
+      AddAdventurer.new!(%{name: "Sir Stephen Bolton", class: :knight, quest_id: quest.id})
+      |> AddAdventurer.execute()
+
+    {:ok, adventurer} =
+      GetAdventurer.new!(%{quest_id: quest.id, adventurer_id: adventurer_id})
+      |> GetAdventurer.execute()
+
+    party_leader_actor = %PointQuest.Authentication.Actor.PartyLeader{
+      quest_id: quest.id,
+      leader_id: party_leader.id,
+      adventurer: nil
+    }
+
+    adventurer_actor = %PointQuest.Authentication.Actor.Adventurer{
+      quest_id: quest.id,
+      adventurer: adventurer
+    }
+
+    other_actor = %PointQuest.Authentication.Actor.PartyLeader{
+      quest_id: other_quest.id,
+      leader_id: other_quest.party_leader.id,
+      adventurer: other_quest.party_leader.adventurer
+    }
+
+    %{
+      quest: quest,
+      other_quest: other_quest,
+      party_leader: party_leader,
+      adventurer: adventurer,
+      party_leader_actor: party_leader_actor,
+      adventurer_actor: adventurer_actor,
+      other_actor: other_actor
+    }
+  end
+end


### PR DESCRIPTION
Move the attack policy checks into the Quests.Spec module. This ensures that:

- Policy checks live in a logical and central area in the Quests domain
- Policy checks are generalized, pure functions that can be used anywhere