### PR TITLE
feat: move to NotFound error struct

### DIFF
--- a/lib/infra/quests/db.ex
+++ b/lib/infra/quests/db.ex
@@ -5,6 +5,7 @@ defmodule Infra.Quests.Db do
   @behaviour PointQuest.Behaviour.Quests.Repo
 
   alias Infra.Quests.QuestServer
+  alias PointQuest.Error
   alias PointQuest.Quests.Quest
   alias PointQuest.Quests.Event
 
@@ -36,7 +37,7 @@ defmodule Infra.Quests.Db do
   def get_quest_by_id(quest_id) do
     case lookup_quest_server(quest_id) do
       nil ->
-        {:error, :quest_not_found}
+        {:error, Error.NotFound.exception(resource: :quest)}
 
       pid ->
         {:ok, QuestServer.get(pid)}
@@ -51,11 +52,11 @@ defmodule Infra.Quests.Db do
 
       {:ok, %{adventurers: adventurers}} ->
         case Enum.find(adventurers, fn %{id: id} -> id == adventurer_id end) do
-          nil -> {:error, :adventurer_not_found}
+          nil -> {:error, Error.NotFound.exception(resource: :adventurer)}
           adventurer -> {:ok, adventurer}
         end
 
-      {:error, :quest_not_found} = error ->
+      {:error, %Error.NotFound{resource: :quest}} = error ->
         error
     end
   end
@@ -66,7 +67,7 @@ defmodule Infra.Quests.Db do
       {:ok, %{party_leader: %{id: ^leader_id} = party_leader}} ->
         {:ok, party_leader}
 
-      {:error, :quest_not_found} = error ->
+      {:error, %Error.NotFound{resource: :quest}} = error ->
         error
     end
   end
@@ -79,7 +80,7 @@ defmodule Infra.Quests.Db do
       {:ok, %{adventurers: adventurers}} ->
         {:ok, adventurers}
 
-      {:error, :quest_not_found} = error ->
+      {:error, %Error.NotFound{resource: :quest}} = error ->
         error
     end
   end
@@ -99,7 +100,7 @@ defmodule Infra.Quests.Db do
 
     defp get_quest(quest_id) do
       case Infra.Quests.Db.get_quest_by_id(quest_id) do
-        {:error, :quest_not_found} ->
+        {:error, %Error.NotFound{resource: :quest}} ->
           []
 
         {:ok, quest} ->

--- a/lib/point_quest/authentication.ex
+++ b/lib/point_quest/authentication.ex
@@ -4,6 +4,7 @@ defmodule PointQuest.Authentication do
   """
 
   alias PointQuest.Authentication.Actor
+  alias PointQuest.Error
   alias PointQuest.Quests
   alias PointQuest.Quests.Commands
 
@@ -63,7 +64,7 @@ defmodule PointQuest.Authentication do
 
     case Commands.GetAdventurer.execute(get_adventurer) do
       {:ok, adventurer} -> {:ok, PointQuest.Authentication.create_actor(adventurer)}
-      {:error, :quest_not_found} -> {:error, :stale_quest}
+      {:error, %Error.NotFound{resource: :quest}} -> {:error, :stale_quest}
     end
   end
 
@@ -72,7 +73,7 @@ defmodule PointQuest.Authentication do
 
     case Commands.GetPartyLeader.execute(get_leader) do
       {:ok, leader} -> {:ok, PointQuest.Authentication.create_actor(leader)}
-      {:error, :quest_not_found} -> {:error, :stale_quest}
+      {:error, %Error.NotFound{resource: :quest}} -> {:error, :stale_quest}
     end
   end
 

--- a/lib/point_quest/behaviour/quests/repo.ex
+++ b/lib/point_quest/behaviour/quests/repo.ex
@@ -1,12 +1,13 @@
 defmodule PointQuest.Behaviour.Quests.Repo do
-  alias PointQuest.Quests.Event
+  alias PointQuest.Error
   alias PointQuest.Quests
+  alias PointQuest.Quests.Event
 
   @callback write(Quests.Quest.t(), Event.QuestStarted.t()) :: {:ok, Quest.t()}
   @callback get_quest_by_id(quest_id :: String.t()) ::
-              {:ok, Quests.Quest.t()} | {:error, :quest_not_found}
+              {:ok, Quests.Quest.t()} | {:error, Error.NotFound.t(:quest)}
   @callback get_adventurer_by_id(quest_id :: String.t(), adventurer_id :: String.t()) ::
-              {:ok, Quests.Adventurer.t()} | {:error, :adventurer_not_found | :quest_not_found}
+              {:ok, Quests.Adventurer.t()} | {:error, Error.NotFound.t(:adventurer | :quest)}
   @callback get_party_leader_by_id(quest_id :: String.t(), leader_id: String.t()) ::
-              {:ok, Quests.PartyLeader.t()} | {:error, :quest_not_found}
+              {:ok, Quests.PartyLeader.t()} | {:error, Error.NotFound.t(:quest)}
 end

--- a/lib/point_quest/error.ex
+++ b/lib/point_quest/error.ex
@@ -1,0 +1,35 @@
+defmodule PointQuest.Error.NotFound do
+  @moduledoc """
+  Error for when a resource cannot be found.
+
+  ```elixir
+  Error.NotFound.exception(resource: :quest)
+  ```
+  """
+
+  @type t(resource) :: %__MODULE__{
+          resource: resource,
+          message: String.t()
+        }
+
+  @type t :: %__MODULE__{
+          resource: any() | nil,
+          message: String.t()
+        }
+
+  defexception [:message, :resource]
+
+  @doc """
+  Return error when `resource` cannot be found
+
+  ```elixir
+  %PointQuest.Error.NotFound{resource: :quest, message: ":quest not found"} = PointQuest.Error.NotFound.exception(resource: :quest)
+  ```
+  """
+  def exception(opts) do
+    %__MODULE__{
+      resource: opts[:resource],
+      message: "#{inspect(opts[:resource])} not found"
+    }
+  end
+end

--- a/lib/point_quest/quests/commands/get_adventurer.ex
+++ b/lib/point_quest/quests/commands/get_adventurer.ex
@@ -8,6 +8,7 @@ defmodule PointQuest.Quests.Commands.GetAdventurer do
   """
   use Ecto.Schema
   import Ecto.Changeset
+  alias PointQuest.Error
 
   @type t :: %__MODULE__{
           quest_id: String.t(),
@@ -73,8 +74,7 @@ defmodule PointQuest.Quests.Commands.GetAdventurer do
 
   @spec execute(t()) ::
           {:ok, PointQuest.Quests.Adventurer.t()}
-          | {:error, :quest_not_found}
-          | {:error, :adventurer_not_found}
+          | {:error, Error.NotFound.t(:adventurer | :quest)}
   @doc """
   Executes the query to return the adventurer, if found.
 

--- a/lib/point_quest/quests/commands/get_party_leader.ex
+++ b/lib/point_quest/quests/commands/get_party_leader.ex
@@ -11,6 +11,7 @@ defmodule PointQuest.Quests.Commands.GetPartyLeader do
   """
   use Ecto.Schema
   import Ecto.Changeset
+  alias PointQuest.Error
 
   @type t :: %__MODULE__{
           quest_id: String.t(),
@@ -76,7 +77,7 @@ defmodule PointQuest.Quests.Commands.GetPartyLeader do
 
   @spec execute(t()) ::
           {:ok, PointQuest.Quests.PartyLeader.t()}
-          | {:error, :quest_not_found}
+          | {:error, Error.NotFound.t(:quest)}
   @doc """
   Executes the query to return the adventurer, if found.
 

--- a/lib/point_quest_web/live/quest.ex
+++ b/lib/point_quest_web/live/quest.ex
@@ -4,6 +4,7 @@ defmodule PointQuestWeb.QuestLive do
   """
   use PointQuestWeb, :live_view
 
+  alias PointQuest.Error
   alias PointQuest.Quests.Event
   alias PointQuest.Authentication.Actor.PartyLeader
   alias PointQuestWeb.Live.Components
@@ -69,7 +70,7 @@ defmodule PointQuestWeb.QuestLive do
         {:error, :missing} ->
           redirect(socket, to: ~p"/quest/#{params["id"]}/join")
 
-        {:error, :quest_not_found} ->
+        {:error, %Error.NotFound{resource: :quest}} ->
           redirect(socket, to: ~p"/quest")
       end
 

--- a/lib/point_quest_web/live/quest_join.ex
+++ b/lib/point_quest_web/live/quest_join.ex
@@ -1,6 +1,7 @@
 defmodule PointQuestWeb.QuestJoinLive do
   use PointQuestWeb, :live_view
 
+  alias PointQuest.Error
   alias PointQuest.Quests.Commands.GetAdventurer
   alias PointQuest.Quests.Commands.AddAdventurer
   alias PointQuest.Quests.Quest
@@ -34,7 +35,7 @@ defmodule PointQuestWeb.QuestJoinLive do
         {:in_quest?, true} ->
           redirect(socket, to: ~p"/quest/#{params["id"]}")
 
-        {:error, :quest_not_found} ->
+        {:error, %Error.NotFound{resource: :quest}} ->
           redirect(socket, to: ~p"/quest")
       end
 

--- a/test/point_quest/error_test.exs
+++ b/test/point_quest/error_test.exs
@@ -1,0 +1,5 @@
+defmodule PointQuest.ErrorTest do
+  use ExUnit.Case, async: true
+  alias PointQuest.Error
+  doctest PointQuest.Error.NotFound
+end

--- a/test/point_quest/quests/commands/attack_test.exs
+++ b/test/point_quest/quests/commands/attack_test.exs
@@ -3,6 +3,7 @@ defmodule PointQuest.Quests.Commands.AttackTest do
 
   import ExUnit.CaptureLog
 
+  alias PointQuest.Error
   alias PointQuest.Quests.Event
   alias PointQuest.Quests.Commands.Attack
   alias PointQuest.Quests.Commands.StartQuest
@@ -163,7 +164,7 @@ defmodule PointQuest.Quests.Commands.AttackTest do
         adventurer_id: adventurer.id,
         attack: 5,
         actor: actor,
-        error: :quest_not_found
+        error: Error.NotFound.exception(resource: :quest)
       })
     end
   end


### PR DESCRIPTION
This change introduces a new `Error` namespace that we can use to add errors to the codebase. Instead of needing to make up error atoms all over the place we can use more generalized errors and build tooling around them.

The first error I went with is the `NotFound` since its popping up lot in our system. Defining these as exceptions instead of structs is nice to give a hint at their meaning. They are also throwable if we wanted to treat them as hard exceptions, but they also do well representing returnable errors.

Closes: PQ-87