### PR TITLE
feat: introduce round_started event and start_round command

### DIFF
--- a/lib/point_quest/quests/commands/start_round.ex
+++ b/lib/point_quest/quests/commands/start_round.ex
@@ -1,0 +1,85 @@
+defmodule PointQuest.Quests.Commands.StartRound do
+  @moduledoc """
+  Command to start a round for the current quest.
+
+  Ensure that you're calling either `new/1` or `new!/1` followed by `execute/1` in order to
+  update the quest.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias PointQuest.Quests
+  alias PointQuest.Authentication
+
+  @type t :: %__MODULE__{
+          quest_id: String.t()
+        }
+
+  @primary_key false
+  embedded_schema do
+    field :quest_id, :string
+  end
+
+  @spec new(map()) :: {:ok, t()}
+  @doc """
+  Creates a command to start a round on the current quest.
+
+  Returns a response tuple with the command.
+  """
+  def new(params) do
+    %__MODULE__{}
+    |> changeset(params)
+    |> apply_action(:update)
+  end
+
+  @spec new!(map()) :: t()
+  @doc """
+  Creates a command to start a round on the current quest.
+
+  Returns the command.
+  """
+  def new!(params) do
+    %__MODULE__{}
+    |> changeset(params)
+    |> apply_action!(:update)
+  end
+
+  @spec changeset(start_round :: t(), params :: map()) :: Ecto.Changeset.t(t())
+  @doc """
+  Creates a changeset from start_round and params.
+  """
+  def changeset(start_round, params \\ %{}) do
+    start_round
+    |> cast(params, [:quest_id])
+    |> validate_required([:quest_id])
+  end
+
+  defp repo(), do: Application.get_env(:point_quest, PointQuest.Behaviour.Quests.Repo)
+
+  @spec execute(start_round_command :: t(), actor :: Authentication.PartyLeader.t()) ::
+          {:ok, Quests.Event.RoundStarted.t()}
+          | {:error, Error.NotFound.exception(resource: :quest)}
+          | {:error, :must_be_leader_of_quest_party}
+          | {:error, :round_already_active}
+  @doc """
+  Executes the command to start the round, given the command struct and an actor.
+
+  Returns a result tuple.
+  """
+  def execute(%__MODULE__{} = start_round_command, actor) do
+    with {:ok, quest} <- repo().get_quest_by_id(start_round_command.quest_id),
+         true <- can_start_round?(quest, actor),
+         {:ok, event} <- Quests.Quest.handle(start_round_command, quest),
+         {:ok, _quest} <- repo().write(quest, event) do
+      {:ok, event}
+    else
+      false -> {:error, :must_be_leader_of_quest_party}
+      {:error, _error} = error -> error
+    end
+  end
+
+  defp can_start_round?(quest, actor) do
+    [Quests.Spec.is_party_leader?(quest, actor)]
+    |> Enum.all?()
+  end
+end

--- a/lib/point_quest/quests/events/round_started.ex
+++ b/lib/point_quest/quests/events/round_started.ex
@@ -1,0 +1,23 @@
+defmodule PointQuest.Quests.Event.RoundStarted do
+  @moduledoc """
+  Update a quest to start a new round.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  embedded_schema do
+    field :quest_id, :string
+  end
+
+  def new!(params) do
+    %__MODULE__{}
+    |> changeset(params)
+    |> apply_action!(:update)
+  end
+
+  def changeset(round_started, params \\ %{}) do
+    round_started
+    |> cast(params, [:quest_id])
+  end
+end

--- a/lib/point_quest/quests/spec.ex
+++ b/lib/point_quest/quests/spec.ex
@@ -50,4 +50,16 @@ defmodule PointQuest.Quests.Spec do
 
   def is_in_party?(%Quest{id: quest_id}, %Actor.Adventurer{quest_id: quest_id}), do: true
   def is_in_party?(%Quest{id: _quest_id}, %Actor.Adventurer{quest_id: _other_quest}), do: false
+
+  @spec is_party_leader?(quest :: Quest.t(), actor :: Actor.t()) :: boolean
+  @doc """
+  Ensures the actor is the party leader of the provided quest
+  """
+  def is_party_leader?(%Quest{party_leader: %{id: id}}, %Actor.PartyLeader{leader_id: id}),
+    do: true
+
+  def is_party_leader?(%Quest{party_leader: %{id: _id}}, %Actor.PartyLeader{leader_id: _other_id}),
+    do: false
+
+  def is_party_leader?(_quest, %Actor.Adventurer{}), do: false
 end

--- a/test/point_quest/error_test.exs
+++ b/test/point_quest/error_test.exs
@@ -1,5 +1,4 @@
 defmodule PointQuest.ErrorTest do
   use ExUnit.Case, async: true
-  alias PointQuest.Error
   doctest PointQuest.Error.NotFound
 end

--- a/test/point_quest/quests/commands/start_round_test.exs
+++ b/test/point_quest/quests/commands/start_round_test.exs
@@ -1,0 +1,94 @@
+defmodule PointQuest.Quests.Commands.StartRoundTest do
+  use ExUnit.Case
+
+  alias PointQuest.Quests.Commands.StartRound
+  alias PointQuest.Quests.Event.RoundStarted
+
+  setup do
+    {:ok, QuestSetupHelper.setup()}
+  end
+
+  describe "new/1" do
+    test "returns ok tuple if valid", %{quest: %{id: quest_id}} do
+      assert {:ok, %StartRound{quest_id: ^quest_id}} =
+               StartRound.new(%{quest_id: quest_id})
+    end
+
+    test "returns error tuple if quest id omitted" do
+      assert {:error, %{valid?: false}} = StartRound.new(%{})
+    end
+  end
+
+  describe "new!/1" do
+    test "returns command if valid", %{quest: %{id: quest_id}} do
+      assert %StartRound{quest_id: ^quest_id} = StartRound.new!(%{quest_id: quest_id})
+    end
+
+    test "throws if quest id is omitted" do
+      assert_raise Ecto.InvalidChangesetError, fn -> StartRound.new!(%{}) end
+    end
+  end
+
+  describe "changeset/2" do
+    test "returns changeset if valid" do
+      assert %{valid?: true, changes: %{quest_id: "abc123"}} =
+               StartRound.changeset(%StartRound{}, %{quest_id: "abc123"})
+    end
+
+    test "returns error changeset if invalid" do
+      assert %{valid?: false, errors: [quest_id: {"can't be blank", _validation}]} =
+               StartRound.changeset(%StartRound{}, %{})
+    end
+  end
+
+  describe "execute/2" do
+    test "returns event when successful", %{quest: %{id: quest_id}, party_leader_actor: actor} do
+      assert {:ok, %RoundStarted{quest_id: ^quest_id}} =
+               %{quest_id: quest_id}
+               |> StartRound.new!()
+               |> StartRound.execute(actor)
+    end
+
+    test "returns error if quest doesn't exist", %{party_leader_actor: actor} do
+      assert {:error, %PointQuest.Error.NotFound{resource: :quest}} =
+               %{quest_id: "abc123"}
+               |> StartRound.new!()
+               |> StartRound.execute(actor)
+    end
+
+    test "returns error if actor is not party leader of provided quest", %{
+      quest: %{id: quest_id},
+      other_actor: actor
+    } do
+      assert {:error, :must_be_leader_of_quest_party} =
+               %{quest_id: quest_id}
+               |> StartRound.new!()
+               |> StartRound.execute(actor)
+    end
+
+    test "returns error if round is started by non-party leader", %{
+      quest: %{id: quest_id},
+      adventurer_actor: actor
+    } do
+      assert {:error, :must_be_leader_of_quest_party} =
+               %{quest_id: quest_id}
+               |> StartRound.new!()
+               |> StartRound.execute(actor)
+    end
+
+    test "returns error if round is already active on provided quest", %{
+      quest: %{id: quest_id},
+      party_leader_actor: actor
+    } do
+      assert {:ok, %RoundStarted{}} =
+               %{quest_id: quest_id}
+               |> StartRound.new!()
+               |> StartRound.execute(actor)
+
+      assert {:error, :round_already_active} =
+               %{quest_id: quest_id}
+               |> StartRound.new!()
+               |> StartRound.execute(actor)
+    end
+  end
+end

--- a/test/point_quest/quests/spec_test.exs
+++ b/test/point_quest/quests/spec_test.exs
@@ -70,4 +70,27 @@ defmodule PointQuest.Quests.SpecTest do
       refute Spec.is_in_party?(quest, actor)
     end
   end
+
+  describe "is_party_leader?/2" do
+    test "policy check succeeds if actor is leader of provided quest", %{
+      quest: quest,
+      party_leader_actor: actor
+    } do
+      assert Spec.is_party_leader?(quest, actor)
+    end
+
+    test "policy check fails if actor is a party leader of different quest", %{
+      other_quest: quest,
+      party_leader_actor: actor
+    } do
+      refute Spec.is_party_leader?(quest, actor)
+    end
+
+    test "policy check fails if actor is not a party leader", %{
+      quest: quest,
+      adventurer_actor: actor
+    } do
+      refute Spec.is_party_leader?(quest, actor)
+    end
+  end
 end


### PR DESCRIPTION
In order to constrain the behavior of when adventurers are allowed to attack, we need to introduce the concept of a "round". A round is a collection of attacks against a single issue.

Rounds are tracked on the quest state in the `round_active?` boolean field.