### PR TITLE
feat: handle round start in UI

### DIFF
--- a/lib/infra/quests/event_handler.ex
+++ b/lib/infra/quests/event_handler.ex
@@ -10,7 +10,8 @@ defmodule Infra.Quests.EventHandler do
     :telemetry.attach_many(
       __MODULE__,
       [
-        attack(:stop)
+        attack(:stop),
+        round_started(:stop)
       ],
       &__MODULE__.handle_event/4,
       nil
@@ -38,6 +39,19 @@ defmodule Infra.Quests.EventHandler do
       ) do
     Logger.error(
       "Adventurer #{Actor.get_actor_id(actor)} failed to attack in quest #{command.quest_id}: #{inspect(reason)}"
+    )
+  end
+
+  def handle_event(
+        round_started(:stop),
+        _measurements,
+        %{event: %Event.RoundStarted{} = round_started, actor: _actor},
+        _config
+      ) do
+    Phoenix.PubSub.broadcast(
+      PointQuestWeb.PubSub,
+      round_started.quest_id,
+      round_started
     )
   end
 end

--- a/lib/point_quest/quests/telemetry.ex
+++ b/lib/point_quest/quests/telemetry.ex
@@ -5,4 +5,5 @@ defmodule PointQuest.Quests.Telemetry do
 
   defevent(:attack, @prefix ++ [:attack])
   defevent(:add_adventurer, @prefix ++ [:add_adventurer])
+  defevent(:round_started, @prefix ++ [:round_started])
 end


### PR DESCRIPTION
Made some updates to the UI to hide and show attacks bar when the round isn't started and a new button to start a round.

Closes: PQ-88