### PR TITLE
feat: introduce round_ended and stop_round command

### DIFF
--- a/lib/point_quest/quests/commands/stop_round.ex
+++ b/lib/point_quest/quests/commands/stop_round.ex
@@ -1,0 +1,85 @@
+defmodule PointQuest.Quests.Commands.StopRound do
+  @moduledoc """
+  Command to stop a round for the current quest.
+
+  Ensure that you're calling either `new/1` or `new!/1` followed by execute in order to
+  update the quest.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias PointQuest.Quests
+  alias PointQuest.Authentication
+
+  @type t :: %__MODULE__{
+          quest_id: String.t()
+        }
+
+  @primary_key false
+  embedded_schema do
+    field :quest_id
+  end
+
+  @spec new(map()) :: {:ok, t()}
+  @doc """
+  Creates a command to stop a round on the current quest.
+
+  Returns a response tuple with the command.
+  """
+  def new(params) do
+    %__MODULE__{}
+    |> changeset(params)
+    |> apply_action(:update)
+  end
+
+  @spec new!(map()) :: t()
+  @doc """
+  Creates a command to stop a round on the current quest.
+
+  Returns the command.
+  """
+  def new!(params) do
+    %__MODULE__{}
+    |> changeset(params)
+    |> apply_action!(:update)
+  end
+
+  @spec changeset(stop_round :: t(), params :: map()) :: Changeset.t(t())
+  @doc """
+  Creates a changeset from stop_round and params.
+  """
+  def changeset(stop_round, params \\ %{}) do
+    stop_round
+    |> cast(params, [:quest_id])
+    |> validate_required([:quest_id])
+  end
+
+  defp repo(), do: Application.get_env(:point_quest, PointQuest.Behaviour.Quests.Repo)
+
+  @spec execute(stop_round_command :: t(), actor :: Authentication.PartyLeader.t()) ::
+          {:ok, t()}
+          | {:error, Error.NotFound.exception(resource: :quest)}
+          | {:error, :must_be_leader_of_quest_party}
+          | {:error, :round_not_active}
+  @doc """
+  Executes the command to stop the round.
+
+  Returns the command.
+  """
+  def execute(%__MODULE__{} = stop_round_command, actor) do
+    with {:ok, quest} <- repo().get_quest_by_id(stop_round_command.quest_id),
+         true <- can_stop_round?(quest, actor),
+         {:ok, event} <- Quests.Quest.handle(stop_round_command, quest),
+         {:ok, _quest} <- repo().write(quest, event) do
+      {:ok, event}
+    else
+      false -> {:error, :must_be_leader_of_quest_party}
+      {:error, _error} = error -> error
+    end
+  end
+
+  defp can_stop_round?(quest, actor) do
+    [Quests.Spec.is_party_leader?(quest, actor)]
+    |> Enum.all?()
+  end
+end

--- a/lib/point_quest/quests/events/round_ended.ex
+++ b/lib/point_quest/quests/events/round_ended.ex
@@ -1,0 +1,23 @@
+defmodule PointQuest.Quests.Event.RoundEnded do
+  @moduledoc """
+  Updates a quest to end the current round.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  embedded_schema do
+    field :quest_id, :string
+  end
+
+  def new!(params) do
+    %__MODULE__{}
+    |> changeset(params)
+    |> apply_action!(:update)
+  end
+
+  def changeset(round_ended, params \\ %{}) do
+    round_ended
+    |> cast(params, [:quest_id])
+  end
+end

--- a/lib/point_quest/quests/quest.ex
+++ b/lib/point_quest/quests/quest.ex
@@ -116,6 +116,13 @@ defmodule PointQuest.Quests.Quest do
     }
   end
 
+  def project(%Event.RoundEnded{}, %__MODULE__{} = quest) do
+    %__MODULE__{
+      quest
+      | round_active?: false
+    }
+  end
+
   def handle(%Commands.StartQuest{} = command, _quest) do
     {:ok, Event.QuestStarted.new!(Ecto.embedded_dump(command, :json))}
     # {:error, error}
@@ -138,6 +145,14 @@ defmodule PointQuest.Quests.Quest do
       {:error, :round_already_active}
     else
       {:ok, Event.RoundStarted.new!(Ecto.embedded_dump(command, :json))}
+    end
+  end
+
+  def handle(%Commands.StopRound{} = command, quest) do
+    if quest.round_active? do
+      {:ok, Event.RoundEnded.new!(Ecto.embedded_dump(command, :json))}
+    else
+      {:error, :round_not_active}
     end
   end
 end

--- a/test/point_quest/quests/commands/stop_round_test.exs
+++ b/test/point_quest/quests/commands/stop_round_test.exs
@@ -1,0 +1,97 @@
+defmodule PointQuest.Quests.Commands.StopRoundTest do
+  use ExUnit.Case
+
+  alias PointQuest.Quests.Commands.StartRound
+  alias PointQuest.Quests.Commands.StopRound
+  alias PointQuest.Quests.Event.RoundEnded
+  alias PointQuest.Quests.Event.RoundStarted
+
+  setup do
+    {:ok, QuestSetupHelper.setup()}
+  end
+
+  describe "new/1" do
+    test "returns ok tuple if valid", %{quest: %{id: quest_id}} do
+      assert {:ok, %StopRound{quest_id: ^quest_id}} =
+               StopRound.new(%{quest_id: quest_id})
+    end
+
+    test "returns error tuple if quest id is omitted" do
+      assert {:error, %{valid?: false}} = StopRound.new(%{})
+    end
+  end
+
+  describe "new!/1" do
+    test "returns command if valid", %{quest: %{id: quest_id}} do
+      assert %StopRound{quest_id: ^quest_id} = StopRound.new!(%{quest_id: quest_id})
+    end
+
+    test "throws if quest id is omitted" do
+      assert_raise Ecto.InvalidChangesetError, fn -> StopRound.new!(%{}) end
+    end
+  end
+
+  describe "changeset/2" do
+    test "returns changeset if valid", %{quest: %{id: quest_id}} do
+      assert %{valid?: true, changes: %{quest_id: ^quest_id}} =
+               StopRound.changeset(%StopRound{}, %{quest_id: quest_id})
+    end
+
+    test "returns error if changeset is invalid" do
+      assert %{valid?: false, errors: [quest_id: {"can't be blank", _validation}]} =
+               StopRound.changeset(%StopRound{}, %{})
+    end
+  end
+
+  describe "execute/2" do
+    test "returns event when successful", %{quest: %{id: quest_id}, party_leader_actor: actor} do
+      # start the round
+      assert {:ok, %RoundStarted{quest_id: ^quest_id}} =
+               %{quest_id: quest_id}
+               |> StartRound.new!()
+               |> StartRound.execute(actor)
+
+      assert {:ok, %RoundEnded{quest_id: ^quest_id}} =
+               %{quest_id: quest_id}
+               |> StopRound.new!()
+               |> StopRound.execute(actor)
+    end
+
+    test "returns error if quest doesn't exist", %{party_leader_actor: actor} do
+      assert {:error, %PointQuest.Error.NotFound{resource: :quest}} =
+               %{quest_id: "abc123"}
+               |> StopRound.new!()
+               |> StopRound.execute(actor)
+    end
+
+    test "returns error if actor is not leader of provided quest", %{
+      quest: %{id: quest_id},
+      other_actor: actor
+    } do
+      assert {:error, :must_be_leader_of_quest_party} =
+               %{quest_id: quest_id}
+               |> StopRound.new!()
+               |> StopRound.execute(actor)
+    end
+
+    test "returns error if round is started by non-party leader", %{
+      quest: %{id: quest_id},
+      adventurer_actor: actor
+    } do
+      assert {:error, :must_be_leader_of_quest_party} =
+               %{quest_id: quest_id}
+               |> StopRound.new!()
+               |> StopRound.execute(actor)
+    end
+
+    test "returns error if round is already active on provided quest", %{
+      quest: %{id: quest_id},
+      party_leader_actor: actor
+    } do
+      assert {:error, :round_not_active} =
+               %{quest_id: quest_id}
+               |> StopRound.new!()
+               |> StopRound.execute(actor)
+    end
+  end
+end


### PR DESCRIPTION
When we are ready to end a round, we can use the stop_round command to move the quest into the round_active? = false state. This should prevent adventurers from attacking, as the party leader is indicating that the current objective is not ready or has already been defeated.