### PR TITLE
feat: handle round ended in UI

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -34,6 +34,8 @@ config :point_quest, PointQuest.Behaviour.Quests.Repo, Infra.Quests.Db
 # at the `config/runtime.exs`.
 config :point_quest, PointQuest.Mailer, adapter: Swoosh.Adapters.Local
 
+config :point_quest, env: Mix.env()
+
 # Configure esbuild (the version is required)
 config :esbuild,
   version: "0.17.11",

--- a/lib/infra/quests/event_handler.ex
+++ b/lib/infra/quests/event_handler.ex
@@ -1,4 +1,8 @@
 defmodule Infra.Quests.EventHandler do
+  @moduledoc """
+  Event handlers for the Quests telemetry context.
+  """
+
   import PointQuest.Quests.Telemetry
 
   alias PointQuest.Quests.Event
@@ -8,7 +12,8 @@ defmodule Infra.Quests.EventHandler do
       __MODULE__,
       [
         attack(:stop),
-        round_started(:stop)
+        round_started(:stop),
+        round_ended(:stop)
       ],
       &__MODULE__.handle_event/4,
       nil
@@ -38,6 +43,19 @@ defmodule Infra.Quests.EventHandler do
       PointQuestWeb.PubSub,
       round_started.quest_id,
       round_started
+    )
+  end
+
+  def handle_event(
+        round_ended(:stop),
+        _measurements,
+        %{event: %Event.RoundEnded{} = round_ended, actor: _actor},
+        _config
+      ) do
+    Phoenix.PubSub.broadcast(
+      PointQuestWeb.PubSub,
+      round_ended.quest_id,
+      round_ended
     )
   end
 

--- a/lib/infra/quests/log_handler.ex
+++ b/lib/infra/quests/log_handler.ex
@@ -11,7 +11,8 @@ defmodule Infra.Quests.LogHandler do
       __MODULE__,
       [
         attack(:stop),
-        quest_started(:stop)
+        quest_started(:stop),
+        round_ended(:stop)
       ],
       &__MODULE__.handle_event/4,
       nil
@@ -47,7 +48,19 @@ defmodule Infra.Quests.LogHandler do
     )
   end
 
+  def handle_event(
+        round_ended(:stop),
+        _measurements,
+        %{error: true, reason: reason, actor: actor, command: command},
+        _config
+      ) do
+    Logger.error(
+      "Failed to stop round - #{inspect(reason)}. actor: #{inspect(actor)}, command: #{inspect(command)}"
+    )
+  end
+
   def handle_event(_unhandled, _measurements, _context, _config) do
+    Logger.error("tee hee")
     :ok
   end
 end

--- a/lib/point_quest/quests/commands/stop_round.ex
+++ b/lib/point_quest/quests/commands/stop_round.ex
@@ -11,6 +11,9 @@ defmodule PointQuest.Quests.Commands.StopRound do
   alias PointQuest.Quests
   alias PointQuest.Authentication
 
+  require PointQuest.Quests.Telemetry
+  require Telemetrex
+
   @type t :: %__MODULE__{
           quest_id: String.t()
         }
@@ -67,14 +70,20 @@ defmodule PointQuest.Quests.Commands.StopRound do
   Returns the command.
   """
   def execute(%__MODULE__{} = stop_round_command, actor) do
-    with {:ok, quest} <- repo().get_quest_by_id(stop_round_command.quest_id),
-         true <- can_stop_round?(quest, actor),
-         {:ok, event} <- Quests.Quest.handle(stop_round_command, quest),
-         {:ok, _quest} <- repo().write(quest, event) do
-      {:ok, event}
-    else
-      false -> {:error, :must_be_leader_of_quest_party}
-      {:error, _error} = error -> error
+    Telemetrex.span event: Quests.Telemetry.round_ended(),
+                    context: %{command: stop_round_command, actor: actor} do
+      with {:ok, quest} <- repo().get_quest_by_id(stop_round_command.quest_id),
+           true <- can_stop_round?(quest, actor),
+           {:ok, event} <- Quests.Quest.handle(stop_round_command, quest),
+           {:ok, _quest} <- repo().write(quest, event) do
+        {:ok, event}
+      else
+        false -> {:error, :must_be_leader_of_quest_party}
+        {:error, _error} = error -> error
+      end
+    after
+      {:ok, event} -> %{event: event}
+      {:error, reason} -> %{error: true, reason: reason}
     end
   end
 

--- a/lib/point_quest/quests/telemetry.ex
+++ b/lib/point_quest/quests/telemetry.ex
@@ -1,4 +1,8 @@
 defmodule PointQuest.Quests.Telemetry do
+  @moduledoc """
+  Telemetry helper functions for the Quests context
+  """
+
   import PointQuest.Telemetry
 
   @prefix [:point_quest, :quest]
@@ -7,4 +11,5 @@ defmodule PointQuest.Quests.Telemetry do
   defevent(:add_adventurer, @prefix ++ [:add_adventurer])
   defevent(:quest_started, @prefix ++ [:quest_started])
   defevent(:round_started, @prefix ++ [:round_started])
+  defevent(:round_ended, @prefix ++ [:round_ended])
 end

--- a/lib/point_quest_web/live/quest.ex
+++ b/lib/point_quest_web/live/quest.ex
@@ -18,8 +18,7 @@ defmodule PointQuestWeb.QuestLive do
       <div :if={is_party_leader?(@actor)} id="leader-controls" class="flex justify-between">
         <div id="quest-actions">
           <.button :if={!@round_active?} phx-click="start_round">New round</.button>
-          <.button phx-click="show_attacks">Show Attacks</.button>
-          <.button phx-click="clear_attacks">Clear Attacks</.button>
+          <.button :if={@round_active?} phx-click="stop_round">Show Attacks</.button>
         </div>
         <div id="meta-actions" class="justify-end">
           <.button phx-click="copy_link">Copy Invite Link</.button>
@@ -102,8 +101,13 @@ defmodule PointQuestWeb.QuestLive do
     {:noreply, socket}
   end
 
-  def handle_event("show_attacks", _params, socket) do
-    Logger.info("show attacks is not implemented yet")
+  def handle_event("stop_round", _params, socket) do
+    %{actor: actor, quest: quest} = socket.assigns
+
+    %{quest_id: quest.id}
+    |> Commands.StopRound.new!()
+    |> Commands.StopRound.execute(actor)
+
     {:noreply, socket}
   end
 
@@ -134,6 +138,13 @@ defmodule PointQuestWeb.QuestLive do
     {
       :noreply,
       assign(socket, round_active?: true)
+    }
+  end
+
+  def handle_info(%Event.RoundEnded{}, socket) do
+    {
+      :noreply,
+      assign(socket, round_active?: false)
     }
   end
 

--- a/lib/point_quest_web/telemetry.ex
+++ b/lib/point_quest_web/telemetry.ex
@@ -12,7 +12,17 @@ defmodule PointQuestWeb.Telemetry do
       # Telemetry poller will execute the given period measurements
       # every 10_000ms. Learn more here: https://hexdocs.pm/telemetry_metrics
       {:telemetry_poller, measurements: periodic_measurements(), period: 10_000},
-      {Infra.TelemetryWatcher, handlers: [Infra.Quests.EventHandler, Infra.Quests.LogHandler]}
+      {Infra.TelemetryWatcher,
+       handlers:
+         [
+           Infra.Quests.EventHandler,
+           if Application.get_env(:point_quest, :env) == :test do
+             []
+           else
+             [Infra.Quests.LogHandler]
+           end
+         ]
+         |> List.flatten()}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/test/point_quest/quests/commands/attack_test.exs
+++ b/test/point_quest/quests/commands/attack_test.exs
@@ -1,8 +1,6 @@
 defmodule PointQuest.Quests.Commands.AttackTest do
   use ExUnit.Case
 
-  import ExUnit.CaptureLog
-
   alias PointQuest.Error
   alias PointQuest.Quests.Commands.Attack
 
@@ -131,21 +129,13 @@ defmodule PointQuest.Quests.Commands.AttackTest do
            actor: actor,
            error: error
          }) do
-      log =
-        capture_log(fn ->
-          assert {:error, ^error} =
-                   Attack.new!(%{
-                     quest_id: quest_id,
-                     adventurer_id: adventurer_id,
-                     attack: attack
-                   })
-                   |> Attack.execute(actor)
-        end)
-
-      actor_id = PointQuest.Authentication.Actor.get_actor_id(actor)
-
-      assert log =~
-               "Adventurer #{actor_id} failed to attack in quest #{quest_id}"
+      assert {:error, ^error} =
+               Attack.new!(%{
+                 quest_id: quest_id,
+                 adventurer_id: adventurer_id,
+                 attack: attack
+               })
+               |> Attack.execute(actor)
     end
   end
 end


### PR DESCRIPTION
When the party leader is ready to show the attack values, they should be able to click the "show attacks" button, which will end the round. This PR hooks up the UI elements with the provided events and kicks the whole loop off.