### PR TITLE
fix: round_active default state is false and return quest from repo write

### DIFF
--- a/lib/infra/quests/db.ex
+++ b/lib/infra/quests/db.ex
@@ -21,7 +21,7 @@ defmodule Infra.Quests.Db do
         {QuestServer, quest: new_quest}
       )
 
-    {:ok, event}
+    {:ok, new_quest}
   end
 
   def write(quest, event) do

--- a/lib/point_quest/quests/commands/start_quest.ex
+++ b/lib/point_quest/quests/commands/start_quest.ex
@@ -154,11 +154,9 @@ defmodule PointQuest.Quests.Commands.StartQuest do
   def execute(%__MODULE__{} = start_quest_command) do
     Telemetrex.span event: Quests.Telemetry.quest_started(),
                     context: %{command: start_quest_command} do
-      with {:ok, event} <- Quests.Quest.handle(start_quest_command, %Quests.Quest{}) do
-        repo().write(
-          %Quests.Quest{},
-          event
-        )
+      with {:ok, event} <- Quests.Quest.handle(start_quest_command, %Quests.Quest{}),
+           {:ok, _quest} <- repo().write(%Quests.Quest{}, event) do
+        {:ok, event}
       end
     after
       {:ok, event} -> %{event: event}

--- a/lib/point_quest/quests/quest.ex
+++ b/lib/point_quest/quests/quest.ex
@@ -49,7 +49,8 @@ defmodule PointQuest.Quests.Quest do
         adventurers: [],
         party_leader: party_leader,
         name: event.name,
-        all_adventurers_attacking?: false
+        all_adventurers_attacking?: false,
+        round_active?: false
     }
   end
 
@@ -75,7 +76,8 @@ defmodule PointQuest.Quests.Quest do
         adventurers: [],
         party_leader: party_leader,
         name: event.name,
-        all_adventurers_attacking?: false
+        all_adventurers_attacking?: false,
+        round_active?: false
     }
   end
 


### PR DESCRIPTION


We were hitting an error trying to check `not nil` when validating initial quest state in the mount.

Additionally, we accidentally inverted the "commands should return events not state" logic by having the repo return event and not state.