### PR TITLE
feat: capture quest objective when starting new round

### DIFF
--- a/lib/point_quest/quests/commands/start_round.ex
+++ b/lib/point_quest/quests/commands/start_round.ex
@@ -15,12 +15,14 @@ defmodule PointQuest.Quests.Commands.StartRound do
   require Telemetrex
 
   @type t :: %__MODULE__{
-          quest_id: String.t()
+          quest_id: String.t(),
+          quest_objective: String.t()
         }
 
   @primary_key false
   embedded_schema do
     field :quest_id, :string
+    field :quest_objective, :string
   end
 
   @spec new(map()) :: {:ok, t()}
@@ -53,7 +55,7 @@ defmodule PointQuest.Quests.Commands.StartRound do
   """
   def changeset(start_round, params \\ %{}) do
     start_round
-    |> cast(params, [:quest_id])
+    |> cast(params, [:quest_id, :quest_objective])
     |> validate_required([:quest_id])
   end
 

--- a/lib/point_quest/quests/events/round_started.ex
+++ b/lib/point_quest/quests/events/round_started.ex
@@ -8,6 +8,7 @@ defmodule PointQuest.Quests.Event.RoundStarted do
   @primary_key false
   embedded_schema do
     field :quest_id, :string
+    field :quest_objective, :string
   end
 
   def new!(params) do
@@ -18,6 +19,6 @@ defmodule PointQuest.Quests.Event.RoundStarted do
 
   def changeset(round_started, params \\ %{}) do
     round_started
-    |> cast(params, [:quest_id])
+    |> cast(params, [:quest_id, :quest_objective])
   end
 end

--- a/lib/point_quest/quests/quest.ex
+++ b/lib/point_quest/quests/quest.ex
@@ -21,6 +21,7 @@ defmodule PointQuest.Quests.Quest do
     field :name, :string
     field :all_adventurers_attacking?, :boolean
     field :round_active?, :boolean
+    field :quest_objective, :string
   end
 
   def init() do
@@ -50,7 +51,8 @@ defmodule PointQuest.Quests.Quest do
         party_leader: party_leader,
         name: event.name,
         all_adventurers_attacking?: false,
-        round_active?: false
+        round_active?: false,
+        quest_objective: ""
     }
   end
 
@@ -111,11 +113,12 @@ defmodule PointQuest.Quests.Quest do
     }
   end
 
-  def project(%Event.RoundStarted{}, %__MODULE__{} = quest) do
+  def project(%Event.RoundStarted{quest_objective: objective}, %__MODULE__{} = quest) do
     %__MODULE__{
       quest
       | round_active?: true,
-        attacks: []
+        attacks: [],
+        quest_objective: objective
     }
   end
 

--- a/test/point_quest/quests/commands/start_round_test.exs
+++ b/test/point_quest/quests/commands/start_round_test.exs
@@ -12,7 +12,12 @@ defmodule PointQuest.Quests.Commands.StartRoundTest do
 
   describe "new/1" do
     test "returns ok tuple if valid", %{quest: %{id: quest_id}} do
-      assert {:ok, %StartRound{quest_id: ^quest_id}} =
+      assert {:ok, %StartRound{quest_id: ^quest_id, quest_objective: "https://www.google.com"}} =
+               StartRound.new(%{quest_id: quest_id, quest_objective: "https://www.google.com"})
+    end
+
+    test "quest_objective is optional", %{quest: %{id: quest_id}} do
+      assert {:ok, %StartRound{quest_id: ^quest_id, quest_objective: nil}} =
                StartRound.new(%{quest_id: quest_id})
     end
 
@@ -61,7 +66,7 @@ defmodule PointQuest.Quests.Commands.StartRoundTest do
         )
 
       assert {:ok, %RoundStarted{} = round_started} =
-               %{quest_id: quest.id}
+               %{quest_id: quest.id, quest_objective: "https://bitsonthemind.com"}
                |> StartRound.new!()
                |> StartRound.execute(actor)
 


### PR DESCRIPTION
In lieu of having an integration to an issue system like Linear, we allow the party leader to provide a link to the current ticket. This will update in their view as well as the adventurer's view so that everyone has a link to the current focus of the round, and knows what we're attacking.

In the future, we would like to update this logic to dynamically dispatch to the issue provider (Linear, Github, Jira, etc.) in order to populate the issue view into the quest state to be shared amongst all the adventurers without needing to leave the session.