### PR TITLE
refactor: ui polish

### DIFF
--- a/lib/point_quest_web/components/core_components.ex
+++ b/lib/point_quest_web/components/core_components.ex
@@ -369,7 +369,7 @@ defmodule PointQuestWeb.CoreComponents do
         id={@id}
         value={Phoenix.HTML.Form.normalize_value(@type, @value)}
         class={[
-          "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6",
+          "#{if @label, do: "mt-2", else: ""} block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6",
           "phx-no-feedback:border-zinc-300 phx-no-feedback:focus:border-zinc-400",
           @errors == [] && "border-zinc-300 focus:border-zinc-400",
           @errors != [] && "border-rose-400 focus:border-rose-400"

--- a/lib/point_quest_web/components/layouts/app.html.heex
+++ b/lib/point_quest_web/components/layouts/app.html.heex
@@ -1,5 +1,5 @@
-<header class="px-4 sm:px-6 lg:px-8">
-  <div class="flex items-center justify-between border-b border-zinc-100 py-3 text-sm">
+<header class="px-4 sm:px-6 lg:px-8 mb-6">
+  <div class="flex items-center justify-between border-b border-zinc-100 py-3 text-sm mx-auto container">
     <div class="flex items-center gap-4">
       <a href="/" class="logo text-xl">
         Point Quest
@@ -8,9 +8,7 @@
     <div class="flex items-center gap-4 font-semibold leading-6 text-zinc-900"></div>
   </div>
 </header>
-<main class="px-4 py-20 sm:px-6 lg:px-8">
-  <div class="mx-auto max-w-2xl">
-    <.flash_group flash={@flash} />
-    <%= @inner_content %>
-  </div>
+<main class="mx-auto container">
+  <.flash_group flash={@flash} />
+  <%= @inner_content %>
 </main>

--- a/lib/point_quest_web/live/components/attack.ex
+++ b/lib/point_quest_web/live/components/attack.ex
@@ -5,7 +5,7 @@ defmodule PointQuestWeb.Live.Components.Attack do
 
   def render(assigns) do
     ~H"""
-    <div class="flex flex-row rounded-full pt-2">
+    <div class="flex flex-row justify-center pt-16 gap-x-16 flex-wrap">
       <button
         :for={attack <- @attack_list}
         type="action"
@@ -13,11 +13,12 @@ defmodule PointQuestWeb.Live.Components.Attack do
         phx-value-attack={attack}
         phx-target={@myself}
         class={[
-          "p-4 first:rounded-s-full last:rounded-e-full",
+          "w-24 h-24 rotate-45",
+          "border-2",
           get_background_color(attack, @selected_attack)
         ]}
       >
-        <%= attack %>
+        <span class="inline-block -rotate-45 font-bold text-xl"><%= attack %></span>
       </button>
     </div>
     """
@@ -46,6 +47,9 @@ defmodule PointQuestWeb.Live.Components.Attack do
     {:noreply, socket}
   end
 
-  defp get_background_color(attack, attack), do: "bg-amber-400 hover:bg-amber-500"
-  defp get_background_color(_attack, _selected), do: "bg-indigo-400 hover:bg-indigo-500"
+  defp get_background_color(attack, attack),
+    do: "bg-amber-400 hover:bg-amber-500 border-amber-500"
+
+  defp get_background_color(_attack, _selected),
+    do: "bg-indigo-400 hover:bg-indigo-500 border-indigo-500"
 end


### PR DESCRIPTION
Lots of UI changes:
  * Turned the attack tiles into diamonds
  * Centered attack diamonds
  * Added attack tile
  * Customized partly leader toolbar
  * Add Icons

On the party leader toolbar I wanted to try and optimize the controls for what the party leader would be engaging with the most. The invite link makes sense to have on the far right since it isn't interacted with as much as the rounds are being driven. Hopefully moving the core controls to the right makes things easier to work with.

Closes: PQ-98