### PR TITLE
refactor: downsize ui elements and attack tile fix

### DIFF
--- a/lib/point_quest_web/live/components/attack.ex
+++ b/lib/point_quest_web/live/components/attack.ex
@@ -5,7 +5,7 @@ defmodule PointQuestWeb.Live.Components.Attack do
 
   def render(assigns) do
     ~H"""
-    <div class="flex flex-row justify-center pt-16 gap-x-16 flex-wrap">
+    <div class="flex flex-row justify-center pt-16 gap-x-12 flex-wrap">
       <button
         :for={attack <- @attack_list}
         type="action"
@@ -13,7 +13,7 @@ defmodule PointQuestWeb.Live.Components.Attack do
         phx-value-attack={attack}
         phx-target={@myself}
         class={[
-          "w-24 h-24 rotate-45",
+          "mb-8 w-16 h-16 rotate-45",
           "border-2",
           get_background_color(attack, @selected_attack)
         ]}
@@ -34,15 +34,16 @@ defmodule PointQuestWeb.Live.Components.Attack do
     # Quests.AttackValue expects the attack to be an integer
     attack_value = params["attack"]
 
-    %{
-      quest_id: socket.assigns.quest_id,
-      adventurer_id: socket.assigns.actor.adventurer.id,
-      attack: attack_value
-    }
-    |> Attack.new!()
-    |> Attack.execute(socket.assigns.actor)
+    {:ok, adventurerer_attacked} =
+      %{
+        quest_id: socket.assigns.quest_id,
+        adventurer_id: socket.assigns.actor.adventurer.id,
+        attack: attack_value
+      }
+      |> Attack.new!()
+      |> Attack.execute(socket.assigns.actor)
 
-    socket = assign(socket, selected_attack: attack_value)
+    socket = assign(socket, selected_attack: adventurerer_attacked.attack)
 
     {:noreply, socket}
   end

--- a/lib/point_quest_web/live/quest.ex
+++ b/lib/point_quest_web/live/quest.ex
@@ -116,8 +116,12 @@ defmodule PointQuestWeb.QuestLive do
 
   def render_attack_choice(assigns) do
     ~H"""
-    <div class={"#{if @attack, do: "visible", else: "invisible"} relative flex justify-center items-center w-32 h-48 mb-8 bg-stone-300 border-2 border-stone-200 rounded-lg after:absolute after:w-[104%] after:h-[102%] after:top-[5px] after:left-0 after:bg-stone-400 after:-z-10 after:rounded-lg after:shadow-sm"}>
-      <span :if={@reveal_attacks?} class="text-3xl text-stone-700"><%= @attack %></span>
+    <div class={[
+      "#{if @attack, do: "visible", else: "invisible"} relative flex justify-center items-center",
+      "w-16 h-28 mb-8 bg-stone-300 border-2 border-stone-200 rounded-lg",
+      "after:absolute after:w-[104%] after:h-[102%] after:top-[5px] after:left-0 after:bg-stone-400 after:-z-10 after:rounded-lg after:shadow-sm"
+    ]}>
+      <span :if={@reveal_attacks?} class="text-2xl text-stone-700"><%= @attack %></span>
     </div>
     """
   end


### PR DESCRIPTION
I went a bit nuts on the size of the ui with that last polish and this pulls the sizing way down for both the attack tile and the choice card. Also the move to make attack value be cast as an integer in the type had an error which caused us to `"3" == 3` and never highlight the active choice. Fixed that up.

Closes: PQ-108