### PR TITLE
feat: ensure actor is not nil before loading quest page

### DIFF
--- a/lib/point_quest_web/middleware/ensure_actor.ex
+++ b/lib/point_quest_web/middleware/ensure_actor.ex
@@ -1,0 +1,39 @@
+defmodule PointQuestWeb.Middleware.EnsureActor.Plug do
+  @moduledoc """
+  Ensures that an actor is loaded, or else we redirect.
+  """
+  require Logger
+
+  @spec init(keyword()) :: keyword()
+  def init(config), do: config
+
+  @spec call(Plug.Conn.t(), keyword()) :: Plug.Conn.t()
+  def call(%{assigns: %{actor: nil}} = conn, _opts) do
+    Logger.warning("Actor is nil")
+    # TODO: redirect if actor is not preset
+    conn
+  end
+
+  def call(conn, _opts) do
+    Logger.info("Ensured Actor is present")
+    conn
+  end
+end
+
+defmodule PointQuestWeb.Middleware.EnsureActor.Hook do
+  @moduledoc """
+  Ensures that an actor is loaded before liveview's mount is called.
+  """
+  import Phoenix.LiveView
+  require Logger
+
+  @spec on_mount(atom(), map(), map(), Phoenix.LiveView.Socket.t()) ::
+          {atom(), Phoenix.LiveView.Socket.t()}
+  def on_mount(:default, _params, _phx_session, %{assigns: %{actor: nil}} = socket) do
+    {:halt, redirect(socket, to: "/quest")}
+  end
+
+  def on_mount(:default, _params, _phx_session, socket) do
+    {:cont, socket}
+  end
+end

--- a/lib/point_quest_web/middleware/load_actor.ex
+++ b/lib/point_quest_web/middleware/load_actor.ex
@@ -28,6 +28,9 @@ defmodule PointQuestWeb.Middleware.LoadActor.Plug do
 end
 
 defmodule PointQuestWeb.Middleware.LoadActor.Hook do
+  @moduledoc """
+  Attempts to load an actor from the Phoenix Session prior to liveview's mount.
+  """
   import Phoenix.Component
   require Logger
 

--- a/lib/point_quest_web/router.ex
+++ b/lib/point_quest_web/router.ex
@@ -33,15 +33,22 @@ defmodule PointQuestWeb.Router do
     live_dashboard "/dashboard", metrics: PointQuestWeb.Telemetry
   end
 
-  live_session :ensure_actor, on_mount: [PointQuestWeb.Middleware.LoadActor.Hook] do
+  scope "/", PointQuestWeb do
     pipe_through [:browser]
 
-    scope "/", PointQuestWeb do
-      get "/switch/:token", Switch, :set_session
-      live "/quest/:id", QuestLive
+    get "/switch/:token", Switch, :set_session
 
+    live_session :load_actor, on_mount: [PointQuestWeb.Middleware.LoadActor.Hook] do
       live "/quest", QuestStartLive
       live "/quest/:id/join", QuestJoinLive
+    end
+
+    live_session :ensure_actor,
+      on_mount: [
+        PointQuestWeb.Middleware.LoadActor.Hook,
+        PointQuestWeb.Middleware.EnsureActor.Hook
+      ] do
+      live "/quest/:id", QuestLive
 
       forward "/", Middleware.QuestForwarder.Plug
     end


### PR DESCRIPTION
When presented with a `nil` actor, the /quest/[:id] route blows up in fun and exciting ways. Adding the EnsureActor hook enforces that if a user makes it to this route, there is a usable actor on the socket.

If a nil actor is found in this hook, we instead redirect them to the quest start page.