### PR TITLE
chore: prevent dropping below 2 machines

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -19,7 +19,7 @@ kill_signal = 'SIGTERM'
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 2
   processes = ['app']
 
   [http_service.concurrency]


### PR DESCRIPTION
Just while we are sorting out the multi node stuff. Once we have handoff in place and can scale up and down this is something we can change.