### PR TITLE
feat: remove name from quest

### DIFF
--- a/lib/infra/quests/log_handler.ex
+++ b/lib/infra/quests/log_handler.ex
@@ -25,16 +25,16 @@ defmodule Infra.Quests.LogHandler do
         %{event: %Event.QuestStarted{} = quest_started},
         _config
       ) do
-    Logger.info(~s/Quest "#{quest_started.name}" started with id: #{quest_started.quest_id}/)
+    Logger.info(~s/Quest started with id: #{quest_started.quest_id}/)
   end
 
   def handle_event(
         quest_started(:stop),
         _measurements,
-        %{command: start_quest, error: true, reason: reason},
+        %{command: _start_quest, error: true, reason: reason},
         _config
       ) do
-    Logger.info(~s/Quest "#{start_quest.name}" failed to start - #{inspect(reason)}/)
+    Logger.info(~s/Quest failed to start - #{inspect(reason)}/)
   end
 
   def handle_event(

--- a/lib/point_quest/quests/commands/start_quest.ex
+++ b/lib/point_quest/quests/commands/start_quest.ex
@@ -40,13 +40,11 @@ defmodule PointQuest.Quests.Commands.StartQuest do
   end
 
   @type t :: %__MODULE__{
-          name: String.t(),
           party_leaders_adventurer: PartyLeadersAdventurer.t()
         }
 
   @primary_key false
   embedded_schema do
-    field :name, :string
     embeds_one :party_leaders_adventurer, PartyLeadersAdventurer
   end
 
@@ -59,7 +57,7 @@ defmodule PointQuest.Quests.Commands.StartQuest do
   Returns the new quest.
 
   ```elixir
-  PointQuest.Quests.Commands.StartQuest.new!(%{name: "Example Quest", party_leaders_adventurer: %{class: :knight, name: "Stevey Beevey"}})
+  PointQuest.Quests.Commands.StartQuest.new!(%{party_leaders_adventurer: %{class: :knight, name: "Stevey Beevey"}})
   |> PointQuest.Quests.Commands.StartQuest.execute()
 
   {:ok,
@@ -77,7 +75,6 @@ defmodule PointQuest.Quests.Commands.StartQuest do
         quest_id: "XHCV7TZ2"
       }
     },
-    name: "Example Quest",
     all_adventurers_attacking?: false
   }}
   ```

--- a/lib/point_quest/quests/events/quest_started.ex
+++ b/lib/point_quest/quests/events/quest_started.ex
@@ -24,7 +24,6 @@ defmodule PointQuest.Quests.Event.QuestStarted do
   @primary_key false
   embedded_schema do
     field :quest_id, :string
-    field :name, :string
     field :leader_id, :string
     embeds_one :party_leaders_adventurer, PartyLeadersAdventurer
   end

--- a/lib/point_quest/quests/quest.ex
+++ b/lib/point_quest/quests/quest.ex
@@ -18,7 +18,6 @@ defmodule PointQuest.Quests.Quest do
     embeds_many :adventurers, Adventurer
     embeds_many :attacks, Attack
     embeds_one :party_leader, Quests.PartyLeader
-    field :name, :string
     field :all_adventurers_attacking?, :boolean
     field :round_active?, :boolean
     field :quest_objective, :string
@@ -30,7 +29,6 @@ defmodule PointQuest.Quests.Quest do
        id: Nanoid.generate_non_secure(),
        adventurers: [],
        attacks: [],
-       name: nil,
        all_adventurers_attacking?: nil,
        round_active?: false,
        quest_objective: ""
@@ -49,8 +47,7 @@ defmodule PointQuest.Quests.Quest do
     %__MODULE__{
       quest
       | adventurers: [],
-        party_leader: party_leader,
-        name: event.name
+        party_leader: party_leader
     }
   end
 
@@ -75,7 +72,6 @@ defmodule PointQuest.Quests.Quest do
       | id: event.quest_id,
         adventurers: [],
         party_leader: party_leader,
-        name: event.name,
         all_adventurers_attacking?: false,
         round_active?: false
     }

--- a/lib/point_quest_web/live/quest_start.ex
+++ b/lib/point_quest_web/live/quest_start.ex
@@ -9,14 +9,7 @@ defmodule PointQuestWeb.QuestStartLive do
 
   def render(assigns) do
     ~H"""
-    <.form
-      for={@form}
-      class="flex flex-col space-y-6"
-      id="start-quest-form"
-      phx-change="validate_quest"
-      phx-submit="start_quest"
-    >
-      <.input id="quest_name" type="text" field={@form[:name]} label="Quest Name" />
+    <.form for={@form} class="flex flex-col space-y-6" id="start-quest-form" phx-submit="start_quest">
       <.input
         name={:join_as_adventurer}
         value={@join_as_adventurer}
@@ -67,27 +60,16 @@ defmodule PointQuestWeb.QuestStartLive do
     {:noreply, assign(socket, join_as_adventurer: !socket.assigns.join_as_adventurer)}
   end
 
-  def handle_event("validate_quest", %{"start_quest" => params}, socket) do
-    changeset =
-      case StartQuest.new(params) do
-        {:ok, %StartQuest{} = command} -> StartQuest.changeset(command, %{})
-        {:error, changeset} -> changeset
-      end
-
-    {:noreply, assign(socket, form: to_form(changeset))}
-  end
-
   def handle_event(
         "start_quest",
         %{
-          "start_quest" => %{"name" => quest_name, "party_leaders_adventurer" => adventurer},
+          "start_quest" => %{"party_leaders_adventurer" => adventurer},
           "join_as_adventurer" => "true"
         },
         socket
       ) do
     params =
       %{
-        name: quest_name,
         party_leaders_adventurer: %{
           name: adventurer["name"],
           class: adventurer["class"]
@@ -111,13 +93,11 @@ defmodule PointQuestWeb.QuestStartLive do
 
   def handle_event(
         "start_quest",
-        %{"start_quest" => %{"name" => quest_name}, "join_as_adventurer" => "false"},
+        %{"join_as_adventurer" => "false"},
         socket
       ) do
-    params = %{name: quest_name}
-
     {:ok, quest_started} =
-      params
+      %{}
       |> StartQuest.new!()
       |> StartQuest.execute()
 

--- a/test/point_quest/quests/commands/start_quest_test.exs
+++ b/test/point_quest/quests/commands/start_quest_test.exs
@@ -5,30 +5,16 @@ defmodule PointQuest.Quests.Commands.StartQuestTest do
   alias PointQuest.Quests.Commands.StartQuest
 
   describe "new/1" do
-    test "providing only a quest name is valid" do
-      assert {:ok, %StartQuest{name: "initial test", party_leaders_adventurer: nil}} =
-               StartQuest.new(%{
-                 name: "initial test"
-               })
-    end
-
-    test "name is required to start a quest" do
-      assert {:error,
-              %{valid?: false, errors: [name: {"can't be blank", [validation: :required]}]}} =
+    test "providing no params is valid" do
+      assert {:ok, %StartQuest{party_leaders_adventurer: nil}} =
                StartQuest.new(%{})
     end
   end
 
   describe "new!/1" do
-    test "providing only a quest name is valid" do
-      assert %StartQuest{name: "initial test", party_leaders_adventurer: nil} =
-               StartQuest.new!(%{
-                 name: "initial test"
-               })
-    end
-
-    test "failure to provide name results in error" do
-      assert_raise Ecto.InvalidChangesetError, fn -> StartQuest.new!(%{}) end
+    test "providing no params is valid" do
+      assert %StartQuest{party_leaders_adventurer: nil} =
+               StartQuest.new!(%{})
     end
 
     test "failure to provide valid adventurer params results in error" do
@@ -42,14 +28,12 @@ defmodule PointQuest.Quests.Commands.StartQuestTest do
     test "party leader can have an adventurer" do
       assert {:ok,
               %StartQuest{
-                name: "with adventurer",
                 party_leaders_adventurer: %StartQuest.PartyLeadersAdventurer{
                   name: "JSON",
                   class: :knight
                 }
               }} =
                StartQuest.new(%{
-                 name: "with adventurer",
                  party_leaders_adventurer: %{name: "JSON", class: :knight}
                })
     end
@@ -71,7 +55,6 @@ defmodule PointQuest.Quests.Commands.StartQuestTest do
     test "class chosen at random if not provided" do
       assert {:ok,
               %StartQuest{
-                name: "test",
                 party_leaders_adventurer: %{name: "JSON", class: class}
               }} = StartQuest.new(%{name: "test", party_leaders_adventurer: %{name: "JSON"}})
 
@@ -94,7 +77,6 @@ defmodule PointQuest.Quests.Commands.StartQuestTest do
                 }
               }} =
                StartQuest.new(%{
-                 name: "test",
                  party_leaders_adventurer: %{name: "bob", class: :builder}
                })
     end
@@ -102,16 +84,18 @@ defmodule PointQuest.Quests.Commands.StartQuestTest do
 
   describe "execute/1" do
     test "returns new quest state" do
-      {:ok, start_quest} = StartQuest.new(%{name: "test"})
+      {:ok, start_quest} = StartQuest.new(%{})
 
-      assert {:ok, %QuestStarted{quest_id: quest_id, name: "test"}} =
+      assert {:ok, %QuestStarted{quest_id: quest_id}} =
                StartQuest.execute(start_quest)
 
       refute is_nil(quest_id)
     end
 
     test "errors when passed invalid changeset" do
-      {:error, bad_changeset} = StartQuest.new(%{})
+      {:error, bad_changeset} =
+        StartQuest.new(%{party_leaders_adventurer: %{name: "json", class: "fake class"}})
+
       assert_raise FunctionClauseError, fn -> StartQuest.execute(bad_changeset) end
     end
   end

--- a/test/point_quest/quests/quest_test.exs
+++ b/test/point_quest/quests/quest_test.exs
@@ -17,7 +17,6 @@ defmodule PointQuest.Quests.QuestTest do
               %Quests.Quest{
                 adventurers: [],
                 attacks: [],
-                name: nil,
                 all_adventurers_attacking?: nil,
                 quest_objective: ""
               }} = Quests.Quest.init()
@@ -26,19 +25,17 @@ defmodule PointQuest.Quests.QuestTest do
 
   describe "project/2" do
     test "projects the QuestStarted event with no party leader adventurer", %{
-      quest: %{id: quest_id, name: quest_name} = quest,
+      quest: %{id: quest_id} = quest,
       party_leader: %{id: leader_id}
     } do
       event = %Quests.Event.QuestStarted{
         quest_id: quest_id,
-        name: quest_name,
         leader_id: leader_id,
         party_leaders_adventurer: nil
       }
 
       assert %Quests.Quest{
                id: ^quest_id,
-               name: ^quest_name,
                party_leader: %Quests.PartyLeader{
                  id: ^leader_id,
                  quest_id: ^quest_id
@@ -52,19 +49,17 @@ defmodule PointQuest.Quests.QuestTest do
 
     test "projects the QuestStarted event with party leader adventurer", %{
       other_quest:
-        %{id: quest_id, name: quest_name, party_leader: %{id: leader_id, adventurer: adventurer}} =
+        %{id: quest_id, party_leader: %{id: leader_id, adventurer: adventurer}} =
           quest
     } do
       event = %Quests.Event.QuestStarted{
         quest_id: quest_id,
-        name: quest_name,
         leader_id: leader_id,
         party_leaders_adventurer: adventurer
       }
 
       assert %Quests.Quest{
                id: ^quest_id,
-               name: ^quest_name,
                party_leader: %{
                  id: ^leader_id,
                  quest_id: ^quest_id,
@@ -159,19 +154,15 @@ defmodule PointQuest.Quests.QuestTest do
 
   describe "handle/2" do
     test "StartQuest command with no party leader adventurer returns QuestStarted event" do
-      command = Quests.Commands.StartQuest.new!(%{name: "test quest"})
+      command = Quests.Commands.StartQuest.new!(%{})
       {:ok, init} = Quests.Quest.init()
 
-      assert {:ok,
-              %Quests.Event.QuestStarted{
-                name: "test quest"
-              }} = Quests.Quest.handle(command, init)
+      assert {:ok, %Quests.Event.QuestStarted{}} = Quests.Quest.handle(command, init)
     end
 
     test "StartQuest command with party leader adventurer returns QuestStarted event" do
       command =
         Quests.Commands.StartQuest.new!(%{
-          name: "test quest",
           party_leaders_adventurer: %{name: "Scott Stapp", class: :mage}
         })
 
@@ -179,7 +170,6 @@ defmodule PointQuest.Quests.QuestTest do
 
       assert {:ok,
               %Quests.Event.QuestStarted{
-                name: "test quest",
                 party_leaders_adventurer: %{
                   name: "Scott Stapp",
                   class: :mage

--- a/test/support/quest_setup_helper.ex
+++ b/test/support/quest_setup_helper.ex
@@ -8,14 +8,13 @@ defmodule QuestSetupHelper do
 
   def setup() do
     {:ok, quest_started} =
-      StartQuest.new!(%{name: "proper quest"}) |> StartQuest.execute()
+      StartQuest.new!(%{}) |> StartQuest.execute()
 
     {:ok, %{party_leader: party_leader} = quest} =
       Infra.Quests.Db.get_quest_by_id(quest_started.quest_id)
 
     {:ok, quest_started} =
       StartQuest.new!(%{
-        name: "Steve's Shenanigans",
         party_leaders_adventurer: %{name: "Stevey Beevey", class: :mage}
       })
       |> StartQuest.execute()


### PR DESCRIPTION
Name was confusing some of our test subjects, especially considering that name provided minimal value to the end user.