### PR TITLE
refactor: move pcs into party

### DIFF
--- a/lib/infra/quests/db.ex
+++ b/lib/infra/quests/db.ex
@@ -43,10 +43,10 @@ defmodule Infra.Quests.Db do
   @impl PointQuest.Behaviour.Quests.Repo
   def get_adventurer_by_id(quest_id, adventurer_id) do
     case get_quest_by_id(quest_id) do
-      {:ok, %{party_leader: %{adventurer: %{id: ^adventurer_id} = adventurer}}} ->
+      {:ok, %{party: %{party_leader: %{adventurer: %{id: ^adventurer_id} = adventurer}}}} ->
         {:ok, adventurer}
 
-      {:ok, %{adventurers: adventurers}} ->
+      {:ok, %{party: %{adventurers: adventurers}}} ->
         case Enum.find(adventurers, fn %{id: id} -> id == adventurer_id end) do
           nil -> {:error, Error.NotFound.exception(resource: :adventurer)}
           adventurer -> {:ok, adventurer}
@@ -60,7 +60,7 @@ defmodule Infra.Quests.Db do
   @impl PointQuest.Behaviour.Quests.Repo
   def get_party_leader_by_id(quest_id, leader_id) do
     case get_quest_by_id(quest_id) do
-      {:ok, %{party_leader: %{id: ^leader_id} = party_leader}} ->
+      {:ok, %{party: %{party_leader: %{id: ^leader_id} = party_leader}}} ->
         {:ok, party_leader}
 
       {:error, %Error.NotFound{resource: :quest}} = error ->
@@ -70,10 +70,10 @@ defmodule Infra.Quests.Db do
 
   def get_all_adventurers(quest_id) do
     case get_quest_by_id(quest_id) do
-      {:ok, %{party_leader: %{adventurer: leader}, adventurers: adventurers}} ->
+      {:ok, %{party: %{party_leader: %{adventurer: leader}, adventurers: adventurers}}} ->
         {:ok, [leader | adventurers]}
 
-      {:ok, %{adventurers: adventurers}} ->
+      {:ok, %{party: %{adventurers: adventurers}}} ->
         {:ok, adventurers}
 
       {:error, %Error.NotFound{resource: :quest}} = error ->

--- a/lib/point_quest/quests/commands/add_adventurer.ex
+++ b/lib/point_quest/quests/commands/add_adventurer.ex
@@ -75,7 +75,7 @@ defmodule PointQuest.Quests.Commands.AddAdventurer do
   defp repo(), do: Application.get_env(:point_quest, PointQuest.Behaviour.Quests.Repo)
 
   defp ensure_unique_name(changeset) do
-    with {:ok, %{adventurers: adventurers, party_leader: leader}} <-
+    with {:ok, %{party: %{adventurers: adventurers, party_leader: leader}}} <-
            repo().get_quest_by_id(get_field(changeset, :quest_id)) do
       name = get_field(changeset, :name)
 

--- a/lib/point_quest/quests/commands/start_quest.ex
+++ b/lib/point_quest/quests/commands/start_quest.ex
@@ -75,7 +75,6 @@ defmodule PointQuest.Quests.Commands.StartQuest do
         quest_id: "XHCV7TZ2"
       }
     },
-    all_adventurers_attacking?: false
   }}
   ```
   """

--- a/lib/point_quest/quests/party.ex
+++ b/lib/point_quest/quests/party.ex
@@ -1,0 +1,20 @@
+defmodule PointQuest.Quests.Party do
+  @moduledoc """
+  Object for handling the party state.
+  """
+  use PointQuest.Valuable, optional_fields: [:adventurers]
+  use Ecto.Schema
+
+  alias PointQuest.Quests
+
+  @type t :: %__MODULE__{
+          adventurers: [Quests.Adventurer.t()],
+          party_leader: Quests.PartyLeader.t()
+        }
+
+  @primary_key false
+  embedded_schema do
+    embeds_many :adventurers, Quests.Adventurer
+    embeds_one :party_leader, Quests.PartyLeader
+  end
+end

--- a/lib/point_quest/quests/spec.ex
+++ b/lib/point_quest/quests/spec.ex
@@ -55,11 +55,15 @@ defmodule PointQuest.Quests.Spec do
   @doc """
   Ensures the actor is the party leader of the provided quest
   """
-  def is_party_leader?(%Quest{party_leader: %{id: id}}, %Actor.PartyLeader{leader_id: id}),
-    do: true
+  def is_party_leader?(%Quest{party: %{party_leader: %{id: id}}}, %Actor.PartyLeader{
+        leader_id: id
+      }),
+      do: true
 
-  def is_party_leader?(%Quest{party_leader: %{id: _id}}, %Actor.PartyLeader{leader_id: _other_id}),
-    do: false
+  def is_party_leader?(%Quest{party: %{party_leader: %{id: _id}}}, %Actor.PartyLeader{
+        leader_id: _other_id
+      }),
+      do: false
 
   def is_party_leader?(_quest, %Actor.Adventurer{}), do: false
 end

--- a/lib/point_quest_web/live/quest_start.ex
+++ b/lib/point_quest_web/live/quest_start.ex
@@ -84,7 +84,7 @@ defmodule PointQuestWeb.QuestStartLive do
     {:ok, quest} = Infra.Quests.Db.get_quest_by_id(quest_started.quest_id)
 
     token =
-      quest.party_leader
+      quest.party.party_leader
       |> Authentication.create_actor()
       |> Authentication.actor_to_token()
 

--- a/test/point_quest/quests/quest_test.exs
+++ b/test/point_quest/quests/quest_test.exs
@@ -15,9 +15,7 @@ defmodule PointQuest.Quests.QuestTest do
     test "returns expected initial state in tuple" do
       assert {:ok,
               %Quests.Quest{
-                adventurers: [],
                 attacks: [],
-                all_adventurers_attacking?: nil,
                 quest_objective: ""
               }} = Quests.Quest.init()
     end
@@ -36,11 +34,13 @@ defmodule PointQuest.Quests.QuestTest do
 
       assert %Quests.Quest{
                id: ^quest_id,
-               party_leader: %Quests.PartyLeader{
-                 id: ^leader_id,
-                 quest_id: ^quest_id
+               party: %Quests.Party{
+                 party_leader: %Quests.PartyLeader{
+                   id: ^leader_id,
+                   quest_id: ^quest_id
+                 },
+                 adventurers: []
                },
-               adventurers: [],
                attacks: [],
                round_active?: false,
                quest_objective: ""
@@ -49,7 +49,7 @@ defmodule PointQuest.Quests.QuestTest do
 
     test "projects the QuestStarted event with party leader adventurer", %{
       other_quest:
-        %{id: quest_id, party_leader: %{id: leader_id, adventurer: adventurer}} =
+        %{id: quest_id, party: %{party_leader: %{id: leader_id, adventurer: adventurer}}} =
           quest
     } do
       event = %Quests.Event.QuestStarted{
@@ -60,10 +60,12 @@ defmodule PointQuest.Quests.QuestTest do
 
       assert %Quests.Quest{
                id: ^quest_id,
-               party_leader: %{
-                 id: ^leader_id,
-                 quest_id: ^quest_id,
-                 adventurer: ^adventurer
+               party: %Quests.Party{
+                 party_leader: %{
+                   id: ^leader_id,
+                   quest_id: ^quest_id,
+                   adventurer: ^adventurer
+                 }
                }
              } = Quests.Quest.project(event, quest)
     end
@@ -82,7 +84,9 @@ defmodule PointQuest.Quests.QuestTest do
 
       assert %Quests.Quest{
                id: ^quest_id,
-               adventurers: adventurers
+               party: %Quests.Party{
+                 adventurers: adventurers
+               }
              } = Quests.Quest.project(event, quest)
 
       assert Enum.member?(adventurers, %Quests.Adventurer{

--- a/test/support/quest_setup_helper.ex
+++ b/test/support/quest_setup_helper.ex
@@ -8,9 +8,10 @@ defmodule QuestSetupHelper do
 
   def setup() do
     {:ok, quest_started} =
-      StartQuest.new!(%{}) |> StartQuest.execute()
+      StartQuest.new!(%{})
+      |> StartQuest.execute()
 
-    {:ok, %{party_leader: party_leader} = quest} =
+    {:ok, %{party: %{party_leader: party_leader}} = quest} =
       Infra.Quests.Db.get_quest_by_id(quest_started.quest_id)
 
     {:ok, quest_started} =
@@ -42,8 +43,8 @@ defmodule QuestSetupHelper do
 
     other_actor = %PointQuest.Authentication.Actor.PartyLeader{
       quest_id: other_quest.id,
-      leader_id: other_quest.party_leader.id,
-      adventurer: other_quest.party_leader.adventurer
+      leader_id: other_quest.party.party_leader.id,
+      adventurer: other_quest.party.party_leader.adventurer
     }
 
     %{


### PR DESCRIPTION
Moving the party domain a level further into quests instead of having the party leader and adventurers living as top-level quest objects. This aims to facilitate the storytelling of a quest object.

Additionally, removes unused field `all_adventurers_attacking?`
from quest.