### PR TITLE
hotfix: starting a quest

### DIFF
--- a/lib/infra/quests/db.ex
+++ b/lib/infra/quests/db.ex
@@ -11,15 +11,15 @@ defmodule Infra.Quests.Db do
   defstruct []
 
   @impl PointQuest.Behaviour.Quests.Repo
-  def write(quest, %Event.QuestStarted{} = event) do
+  def write(_quest, %Event.QuestStarted{} = event) do
     {:ok, pid} =
       Horde.DynamicSupervisor.start_child(
         Infra.Quests.QuestSupervisor,
-        {QuestServer, quest: quest}
+        {QuestServer, quest_id: event.quest_id}
       )
 
     _event = QuestServer.add_event(pid, event)
-    new_quest = Projectionist.Store.get(Infra.Quests.QuestStore, quest.id)
+    new_quest = Projectionist.Store.get(Infra.Quests.QuestStore, event.quest_id)
 
     {:ok, new_quest}
   end

--- a/lib/point_quest/quests/commands/start_quest.ex
+++ b/lib/point_quest/quests/commands/start_quest.ex
@@ -40,12 +40,30 @@ defmodule PointQuest.Quests.Commands.StartQuest do
   end
 
   @type t :: %__MODULE__{
+          quest_id: String.t(),
           party_leaders_adventurer: PartyLeadersAdventurer.t()
         }
 
   @primary_key false
   embedded_schema do
+    field :quest_id, :string
     embeds_one :party_leaders_adventurer, PartyLeadersAdventurer
+  end
+
+  def changeset(start_quest, params) do
+    start_quest
+    |> cast(params, [:quest_id])
+    |> maybe_new_quest_id()
+    |> validate_required([:quest_id])
+    |> cast_embed(:party_leaders_adventurer)
+  end
+
+  def maybe_new_quest_id(changeset) do
+    if get_change(changeset, :quest_id) do
+      changeset
+    else
+      change(changeset, quest_id: Nanoid.generate_non_secure())
+    end
   end
 
   defp repo(), do: Application.get_env(:point_quest, PointQuest.Behaviour.Quests.Repo)

--- a/lib/point_quest_web/live/quest_start.ex
+++ b/lib/point_quest_web/live/quest_start.ex
@@ -80,6 +80,7 @@ defmodule PointQuestWeb.QuestStartLive do
       params
       |> StartQuest.new!()
       |> StartQuest.execute()
+      |> dbg()
 
     {:ok, quest} = Infra.Quests.Db.get_quest_by_id(quest_started.quest_id)
 
@@ -104,7 +105,7 @@ defmodule PointQuestWeb.QuestStartLive do
     {:ok, quest} = Infra.Quests.Db.get_quest_by_id(quest_started.quest_id)
 
     token =
-      quest.party_leader
+      quest.party.party_leader
       |> Authentication.create_actor()
       |> Authentication.actor_to_token()
 

--- a/lib/point_quest_web/live/quest_start.ex
+++ b/lib/point_quest_web/live/quest_start.ex
@@ -80,7 +80,6 @@ defmodule PointQuestWeb.QuestStartLive do
       params
       |> StartQuest.new!()
       |> StartQuest.execute()
-      |> dbg()
 
     {:ok, quest} = Infra.Quests.Db.get_quest_by_id(quest_started.quest_id)
 

--- a/test/point_quest/quests/commands/start_quest_test.exs
+++ b/test/point_quest/quests/commands/start_quest_test.exs
@@ -6,21 +6,39 @@ defmodule PointQuest.Quests.Commands.StartQuestTest do
 
   describe "new/1" do
     test "providing no params is valid" do
-      assert {:ok, %StartQuest{party_leaders_adventurer: nil}} =
+      assert {:ok, %StartQuest{quest_id: quest_id, party_leaders_adventurer: nil}} =
                StartQuest.new(%{})
+
+      refute is_nil(quest_id)
+    end
+
+    test "quest id can be specified" do
+      quest_id = "abc123"
+
+      assert {:ok, %StartQuest{quest_id: ^quest_id, party_leaders_adventurer: nil}} =
+               StartQuest.new(%{quest_id: quest_id})
     end
   end
 
   describe "new!/1" do
     test "providing no params is valid" do
-      assert %StartQuest{party_leaders_adventurer: nil} =
+      assert %StartQuest{quest_id: quest_id, party_leaders_adventurer: nil} =
                StartQuest.new!(%{})
+
+      refute is_nil(quest_id)
     end
 
     test "failure to provide valid adventurer params results in error" do
       assert_raise Ecto.InvalidChangesetError, fn ->
         StartQuest.new!(%{name: "borked", party_leaders_adventurer: %{class: :knight}})
       end
+    end
+
+    test "quest id can be specified" do
+      quest_id = "abc123"
+
+      assert %StartQuest{quest_id: ^quest_id, party_leaders_adventurer: nil} =
+               StartQuest.new!(%{quest_id: quest_id})
     end
   end
 


### PR DESCRIPTION
We had more quest id confusion that was causing some paths to generate a different quest id that would fail further lookups. I think this is a good lesson that we should avoid auto id generation in as many spots as possible and handle it up front in commands and events.