### PR TITLE
refactor: move current db to in memory namespace

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -22,7 +22,7 @@ config :point_quest, PointQuestWeb.Endpoint,
 # config :point_quest, PointQuest.Behaviour.Linear.Client, PointQuest.Linear.Client
 # config :point_quest, PointQuest.Behaviour.Linear.Repo, PointQuest.Linear.Repo
 config :point_quest, PointQuest.Behaviour.Quests, PointQuest.Quests
-config :point_quest, PointQuest.Behaviour.Quests.Repo, Infra.Quests.Db
+config :point_quest, PointQuest.Behaviour.Quests.Repo, Infra.Quests.InMemory.Db
 # config :point_quest, PointQuest.Behaviour.Ticket, Infra.Linear.Linear
 
 # Configures the mailer

--- a/lib/infra/quests/in_memory/db.ex
+++ b/lib/infra/quests/in_memory/db.ex
@@ -1,10 +1,10 @@
-defmodule Infra.Quests.Db do
+defmodule Infra.Quests.InMemory.Db do
   @moduledoc """
   In-memory DB system
   """
   @behaviour PointQuest.Behaviour.Quests.Repo
 
-  alias Infra.Quests.QuestServer
+  alias Infra.Quests.InMemory
   alias PointQuest.Error
   alias PointQuest.Quests.Event
 
@@ -14,19 +14,19 @@ defmodule Infra.Quests.Db do
   def write(_quest, %Event.QuestStarted{} = event) do
     {:ok, pid} =
       Horde.DynamicSupervisor.start_child(
-        Infra.Quests.QuestSupervisor,
-        {QuestServer, quest_id: event.quest_id}
+        Infra.Quests.InMemory.QuestSupervisor,
+        {InMemory.QuestServer, quest_id: event.quest_id}
       )
 
-    _event = QuestServer.add_event(pid, event)
-    new_quest = Projectionist.Store.get(Infra.Quests.QuestStore, event.quest_id)
+    _event = InMemory.QuestServer.add_event(pid, event)
+    new_quest = Projectionist.Store.get(InMemory.QuestStore, event.quest_id)
 
     {:ok, new_quest}
   end
 
   def write(quest, event) do
-    QuestServer.add_event({:via, Horde.Registry, {Infra.Quests.Registry, quest.id}}, event)
-    {:ok, Projectionist.Store.get(Infra.Quests.QuestStore, quest.id)}
+    InMemory.QuestServer.add_event({:via, Horde.Registry, {InMemory.Registry, quest.id}}, event)
+    {:ok, Projectionist.Store.get(InMemory.QuestStore, quest.id)}
   end
 
   @impl PointQuest.Behaviour.Quests.Repo
@@ -36,7 +36,7 @@ defmodule Infra.Quests.Db do
         {:error, Error.NotFound.exception(resource: :quest)}
 
       _pid ->
-        {:ok, Projectionist.Store.get(Infra.Quests.QuestStore, quest_id)}
+        {:ok, Projectionist.Store.get(InMemory.QuestStore, quest_id)}
     end
   end
 
@@ -82,7 +82,7 @@ defmodule Infra.Quests.Db do
   end
 
   defp lookup_quest_server(quest_id) do
-    case Horde.Registry.lookup(Infra.Quests.Registry, quest_id) do
+    case Horde.Registry.lookup(InMemory.Registry, quest_id) do
       [{pid, _state}] ->
         pid
 

--- a/lib/infra/quests/in_memory/quest_server.ex
+++ b/lib/infra/quests/in_memory/quest_server.ex
@@ -1,4 +1,4 @@
-defmodule Infra.Quests.QuestServer do
+defmodule Infra.Quests.InMemory.QuestServer do
   @moduledoc """
   Agent to hold quest state
   """
@@ -25,7 +25,7 @@ defmodule Infra.Quests.QuestServer do
     GenServer.start_link(
       __MODULE__,
       opts,
-      name: {:via, Horde.Registry, {Infra.Quests.Registry, opts.quest_id}}
+      name: {:via, Horde.Registry, {Infra.Quests.InMemory.Registry, opts.quest_id}}
     )
   end
 

--- a/lib/infra/quests/in_memory/quest_store.ex
+++ b/lib/infra/quests/in_memory/quest_store.ex
@@ -1,9 +1,9 @@
-defmodule Infra.Quests.QuestStore do
+defmodule Infra.Quests.InMemory.QuestStore do
   @moduledoc """
   A store where you can buy and sell quests and quest accessories
   """
   use Projectionist.Store
-  alias Infra.Quests.QuestReader
+  alias Infra.Quests.InMemory.QuestReader
 
   def start_link(_opts) do
     Projectionist.Store.start_link(

--- a/lib/infra/quests/in_memory/supervisor.ex
+++ b/lib/infra/quests/in_memory/supervisor.ex
@@ -1,0 +1,24 @@
+defmodule Infra.Quests.InMemory.Supervisor do
+  @moduledoc """
+  Supervisor for Distributed InMemory Quest database components
+  """
+  use Supervisor
+  alias Infra.Quests.InMemory
+
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def init(_opts) do
+    [
+      # Lookup Game Servers by Quest Id
+      {Horde.Registry, keys: :unique, name: InMemory.Registry, members: :auto},
+      # Manage Game Servers across the cluster
+      {Horde.DynamicSupervisor,
+       name: InMemory.QuestSupervisor, strategy: :one_for_one, members: :auto},
+      # Projections across in memory quest servers
+      InMemory.QuestStore
+    ]
+    |> Supervisor.init(strategy: :one_for_one)
+  end
+end

--- a/lib/point_quest/application.ex
+++ b/lib/point_quest/application.ex
@@ -8,22 +8,14 @@ defmodule PointQuest.Application do
   @impl true
   def start(_type, _args) do
     children = [
-      # Start the Telemetry supervisor
       PointQuestWeb.Telemetry,
-      # Start the Ecto repository
-      Infra.Quests.QuestStore,
-      # Registry for managing quest processes
-      {Horde.Registry, keys: :unique, name: Infra.Quests.Registry, members: :auto},
-      # Start the PubSub system
+      {DNSCluster, query: Application.get_env(:point_quest, :dns_cluster_query) || :ignore},
+      {Finch, name: PointQuest.Finch},
+      # Use in memory quest db behavior
+      Infra.Quests.InMemory.Supervisor,
       {Phoenix.PubSub, name: PointQuestWeb.PubSub},
       PointQuestWeb.Presence,
-      # Start Finch
-      {Finch, name: PointQuest.Finch},
-      {DNSCluster, query: Application.get_env(:point_quest, :dns_cluster_query) || :ignore},
-      # Start the Endpoint (http/https)
-      PointQuestWeb.Endpoint,
-      {Horde.DynamicSupervisor,
-       name: Infra.Quests.QuestSupervisor, strategy: :one_for_one, members: :auto}
+      PointQuestWeb.Endpoint
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/point_quest_web/live/quest_join.ex
+++ b/lib/point_quest_web/live/quest_join.ex
@@ -24,7 +24,7 @@ defmodule PointQuestWeb.QuestJoinLive do
 
   def mount(params, _session, socket) do
     socket =
-      with {:ok, quest} <- Infra.Quests.Db.get_quest_by_id(params["id"]),
+      with {:ok, quest} <- Infra.Quests.InMemory.Db.get_quest_by_id(params["id"]),
            {:in_quest?, false} <- check_actor_in_quest(quest, socket.assigns.actor) do
         changeset = get_changeset(%{quest_id: quest.id})
         classes = PointQuest.Quests.Adventurer.Class.NameEnum.valid_atoms()

--- a/lib/point_quest_web/live/quest_start.ex
+++ b/lib/point_quest_web/live/quest_start.ex
@@ -81,7 +81,7 @@ defmodule PointQuestWeb.QuestStartLive do
       |> StartQuest.new!()
       |> StartQuest.execute()
 
-    {:ok, quest} = Infra.Quests.Db.get_quest_by_id(quest_started.quest_id)
+    {:ok, quest} = Infra.Quests.InMemory.Db.get_quest_by_id(quest_started.quest_id)
 
     token =
       quest.party.party_leader
@@ -101,7 +101,7 @@ defmodule PointQuestWeb.QuestStartLive do
       |> StartQuest.new!()
       |> StartQuest.execute()
 
-    {:ok, quest} = Infra.Quests.Db.get_quest_by_id(quest_started.quest_id)
+    {:ok, quest} = Infra.Quests.InMemory.Db.get_quest_by_id(quest_started.quest_id)
 
     token =
       quest.party.party_leader

--- a/test/infra/quests/quest_server_test.exs
+++ b/test/infra/quests/quest_server_test.exs
@@ -1,7 +1,7 @@
-defmodule Infra.Quests.QuestServerTest do
+defmodule Infra.Quests.InMemory.QuestServerTest do
   use ExUnit.Case, async: true
 
-  alias Infra.Quests.QuestServer
+  alias Infra.Quests.InMemory.QuestServer
   alias PointQuest.Quests
 
   describe "automatic cleanup of old sessions" do
@@ -68,7 +68,7 @@ defmodule Infra.Quests.QuestServerTest do
           })
         )
 
-      {:ok, event_1_projection} = Infra.Quests.Db.get_quest_by_id(quest_id)
+      {:ok, event_1_projection} = Infra.Quests.InMemory.Db.get_quest_by_id(quest_id)
 
       # snapshot not taken yet
       assert ^initial_quest = QuestServer.get_snapshot(quest_server)
@@ -85,7 +85,7 @@ defmodule Infra.Quests.QuestServerTest do
           })
         )
 
-      {:ok, event_2_projection} = Infra.Quests.Db.get_quest_by_id(quest_id)
+      {:ok, event_2_projection} = Infra.Quests.InMemory.Db.get_quest_by_id(quest_id)
 
       # snapshot not taken yet
       assert ^initial_quest = QuestServer.get_snapshot(quest_server)

--- a/test/support/quest_setup_helper.ex
+++ b/test/support/quest_setup_helper.ex
@@ -12,7 +12,7 @@ defmodule QuestSetupHelper do
       |> StartQuest.execute()
 
     {:ok, %{party: %{party_leader: party_leader}} = quest} =
-      Infra.Quests.Db.get_quest_by_id(quest_started.quest_id)
+      Infra.Quests.InMemory.Db.get_quest_by_id(quest_started.quest_id)
 
     {:ok, quest_started} =
       StartQuest.new!(%{
@@ -20,7 +20,7 @@ defmodule QuestSetupHelper do
       })
       |> StartQuest.execute()
 
-    {:ok, other_quest} = Infra.Quests.Db.get_quest_by_id(quest_started.quest_id)
+    {:ok, other_quest} = Infra.Quests.InMemory.Db.get_quest_by_id(quest_started.quest_id)
 
     {:ok, %{id: adventurer_id}} =
       AddAdventurer.new!(%{name: "Sir Stephen Bolton", class: :knight, quest_id: quest.id})


### PR DESCRIPTION
With the couch implementation incoming its nice to get the two implementations separated from each other so that they can be toggled if needed. To make the implementation as self contained as possible I even included a supervisor that bundles that part of the tree. This way we can toggle off the whole supervisor in the case where we don't want the inmemory in production anymore.

Closes: PQ-128