### PR TITLE
feat: add a simple in memory db implementation

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -16,6 +16,9 @@ config :point_quest, PointQuestWeb.Endpoint,
   secret_key_base: "NSik0XTnIRg5eOWsWCHiqI2WMSFVFAdwlCKIvTGqB+nQX5AfhAKfahQ7wCLf46+X",
   server: false
 
+# Configures dependency injection
+config :point_quest, PointQuest.Behaviour.Quests.Repo, Infra.Quests.SimpleInMemory.Db
+
 # In test we don't send emails.
 config :point_quest, PointQuest.Mailer, adapter: Swoosh.Adapters.Test
 

--- a/lib/infra/quests/simple_in_memory/event_server.ex
+++ b/lib/infra/quests/simple_in_memory/event_server.ex
@@ -1,0 +1,26 @@
+defmodule Infra.Quests.SimpleInMemory.EventServer do
+  use Agent
+  alias PointQuest.Quests.Quest
+
+  def start_link(opts) do
+    Agent.start_link(fn -> [] end,
+      name: {:via, Registry, {Infra.Quests.SimpleInMemory.Registry, opts[:quest_id]}}
+    )
+  end
+
+  def add_event(event_store, event) do
+    Agent.update(event_store, fn events ->
+      [event | events]
+    end)
+  end
+
+  def get_quest(event_store) do
+    Agent.get(event_store, fn events ->
+      {:ok, quest} = Quest.init()
+
+      events
+      |> Enum.reverse()
+      |> Enum.reduce(quest, &Quest.project/2)
+    end)
+  end
+end

--- a/lib/infra/quests/simple_in_memory/supervisor.ex
+++ b/lib/infra/quests/simple_in_memory/supervisor.ex
@@ -1,0 +1,19 @@
+defmodule Infra.Quests.SimpleInMemory.Supervisor do
+  @moduledoc """
+  Supervisor for Simple InMemory Quest database components
+  """
+  use Supervisor
+  alias Infra.Quests.SimpleInMemory
+
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def init(_opts) do
+    [
+      {Registry, keys: :unique, name: SimpleInMemory.Registry},
+      {DynamicSupervisor, name: SimpleInMemory.QuestSupervisor, strategy: :one_for_one}
+    ]
+    |> Supervisor.init(strategy: :one_for_one)
+  end
+end

--- a/lib/point_quest.ex
+++ b/lib/point_quest.ex
@@ -9,5 +9,6 @@ defmodule PointQuest do
 
   @spec quest_service() :: module()
   def quest_service(), do: Application.get_env(:point_quest, PointQuest.Behaviour.Quests)
+  def quest_repo(), do: Application.get_env(:point_quest, PointQuest.Behaviour.Quests.Repo)
   def ticket_service(), do: Application.get_env(:point_quest, PointQuest.Behaviour.Ticket)
 end

--- a/lib/point_quest/application.ex
+++ b/lib/point_quest/application.ex
@@ -11,8 +11,8 @@ defmodule PointQuest.Application do
       PointQuestWeb.Telemetry,
       {DNSCluster, query: Application.get_env(:point_quest, :dns_cluster_query) || :ignore},
       {Finch, name: PointQuest.Finch},
-      # Use in memory quest db behavior
       Infra.Quests.InMemory.Supervisor,
+      Infra.Quests.SimpleInMemory.Supervisor,
       {Phoenix.PubSub, name: PointQuestWeb.PubSub},
       PointQuestWeb.Presence,
       PointQuestWeb.Endpoint

--- a/lib/point_quest/behaviour/quests/repo.ex
+++ b/lib/point_quest/behaviour/quests/repo.ex
@@ -10,4 +10,6 @@ defmodule PointQuest.Behaviour.Quests.Repo do
               {:ok, Quests.Adventurer.t()} | {:error, Error.NotFound.t(:adventurer | :quest)}
   @callback get_party_leader_by_id(quest_id :: String.t(), leader_id: String.t()) ::
               {:ok, Quests.PartyLeader.t()} | {:error, Error.NotFound.t(:quest)}
+  @callback get_all_adventurers(quest_id :: String.t()) ::
+              {:ok, [Quests.Adventurer.t()]} | {:error, Error.NotFound.t(:quest)}
 end

--- a/lib/point_quest/quests/commands/add_adventurer.ex
+++ b/lib/point_quest/quests/commands/add_adventurer.ex
@@ -72,11 +72,9 @@ defmodule PointQuest.Quests.Commands.AddAdventurer do
     |> ensure_unique_name()
   end
 
-  defp repo(), do: Application.get_env(:point_quest, PointQuest.Behaviour.Quests.Repo)
-
   defp ensure_unique_name(changeset) do
     with {:ok, %{party: %{adventurers: adventurers, party_leader: leader}}} <-
-           repo().get_quest_by_id(get_field(changeset, :quest_id)) do
+           PointQuest.quest_repo().get_quest_by_id(get_field(changeset, :quest_id)) do
       name = get_field(changeset, :name)
 
       adventurers =
@@ -111,10 +109,10 @@ defmodule PointQuest.Quests.Commands.AddAdventurer do
   def execute(%__MODULE__{quest_id: quest_id} = add_adventurer_command) do
     Telemetrex.span event: Quests.Telemetry.add_adventurer(),
                     context: %{command: add_adventurer_command} do
-      with {:ok, quest} <- repo().get_quest_by_id(quest_id),
+      with {:ok, quest} <- PointQuest.quest_repo().get_quest_by_id(quest_id),
            {:ok, event} <- Quests.Quest.handle(add_adventurer_command, quest),
            {:ok, _quest} <-
-             repo().write(
+             PointQuest.quest_repo().write(
                quest,
                event
              ) do

--- a/lib/point_quest/quests/commands/get_adventurer.ex
+++ b/lib/point_quest/quests/commands/get_adventurer.ex
@@ -20,8 +20,6 @@ defmodule PointQuest.Quests.Commands.GetAdventurer do
     field :adventurer_id, :string
   end
 
-  defp repo(), do: Application.get_env(:point_quest, PointQuest.Behaviour.Quests.Repo)
-
   @spec execute(t()) ::
           {:ok, PointQuest.Quests.Adventurer.t()}
           | {:error, Error.NotFound.t(:adventurer | :quest)}
@@ -42,6 +40,6 @@ defmodule PointQuest.Quests.Commands.GetAdventurer do
   ```
   """
   def execute(%__MODULE__{quest_id: quest_id, adventurer_id: adventurer_id}) do
-    repo().get_adventurer_by_id(quest_id, adventurer_id)
+    PointQuest.quest_repo().get_adventurer_by_id(quest_id, adventurer_id)
   end
 end

--- a/lib/point_quest/quests/commands/get_party_leader.ex
+++ b/lib/point_quest/quests/commands/get_party_leader.ex
@@ -23,8 +23,6 @@ defmodule PointQuest.Quests.Commands.GetPartyLeader do
     field :leader_id, :string
   end
 
-  defp repo(), do: Application.get_env(:point_quest, PointQuest.Behaviour.Quests.Repo)
-
   @spec execute(t()) ::
           {:ok, PointQuest.Quests.PartyLeader.t()}
           | {:error, Error.NotFound.t(:quest)}
@@ -49,6 +47,6 @@ defmodule PointQuest.Quests.Commands.GetPartyLeader do
   ```
   """
   def execute(%__MODULE__{quest_id: quest_id, leader_id: leader_id}) do
-    repo().get_party_leader_by_id(quest_id, leader_id)
+    PointQuest.quest_repo().get_party_leader_by_id(quest_id, leader_id)
   end
 end

--- a/lib/point_quest/quests/commands/start_quest.ex
+++ b/lib/point_quest/quests/commands/start_quest.ex
@@ -66,8 +66,6 @@ defmodule PointQuest.Quests.Commands.StartQuest do
     end
   end
 
-  defp repo(), do: Application.get_env(:point_quest, PointQuest.Behaviour.Quests.Repo)
-
   @spec execute(t()) :: PointQuest.Quests.Quest.t()
   @doc """
   Executes the command to start the quest.
@@ -102,7 +100,7 @@ defmodule PointQuest.Quests.Commands.StartQuest do
     Telemetrex.span event: Quests.Telemetry.quest_started(),
                     context: %{command: start_quest_command} do
       with {:ok, event} <- Quests.Quest.handle(start_quest_command, quest),
-           {:ok, _quest} <- repo().write(quest, event) do
+           {:ok, _quest} <- PointQuest.quest_repo().write(quest, event) do
         {:ok, event}
       end
     after

--- a/lib/point_quest/quests/commands/stop_round.ex
+++ b/lib/point_quest/quests/commands/stop_round.ex
@@ -22,8 +22,6 @@ defmodule PointQuest.Quests.Commands.StopRound do
     field :quest_id
   end
 
-  defp repo(), do: Application.get_env(:point_quest, PointQuest.Behaviour.Quests.Repo)
-
   @spec execute(stop_round_command :: t(), actor :: Authentication.PartyLeader.t()) ::
           {:ok, t()}
           | {:error, Error.NotFound.exception(resource: :quest)}
@@ -37,10 +35,10 @@ defmodule PointQuest.Quests.Commands.StopRound do
   def execute(%__MODULE__{} = stop_round_command, actor) do
     Telemetrex.span event: Quests.Telemetry.round_ended(),
                     context: %{command: stop_round_command, actor: actor} do
-      with {:ok, quest} <- repo().get_quest_by_id(stop_round_command.quest_id),
+      with {:ok, quest} <- PointQuest.quest_repo().get_quest_by_id(stop_round_command.quest_id),
            true <- can_stop_round?(quest, actor),
            {:ok, event} <- Quests.Quest.handle(stop_round_command, quest),
-           {:ok, _quest} <- repo().write(quest, event) do
+           {:ok, _quest} <- PointQuest.quest_repo().write(quest, event) do
         {:ok, event}
       else
         false -> {:error, :must_be_leader_of_quest_party}

--- a/lib/point_quest_web/live/quest_join.ex
+++ b/lib/point_quest_web/live/quest_join.ex
@@ -24,7 +24,7 @@ defmodule PointQuestWeb.QuestJoinLive do
 
   def mount(params, _session, socket) do
     socket =
-      with {:ok, quest} <- Infra.Quests.InMemory.Db.get_quest_by_id(params["id"]),
+      with {:ok, quest} <- PointQuest.quest_repo().get_quest_by_id(params["id"]),
            {:in_quest?, false} <- check_actor_in_quest(quest, socket.assigns.actor) do
         changeset = get_changeset(%{quest_id: quest.id})
         classes = PointQuest.Quests.Adventurer.Class.NameEnum.valid_atoms()

--- a/lib/point_quest_web/live/quest_start.ex
+++ b/lib/point_quest_web/live/quest_start.ex
@@ -81,7 +81,7 @@ defmodule PointQuestWeb.QuestStartLive do
       |> StartQuest.new!()
       |> StartQuest.execute()
 
-    {:ok, quest} = Infra.Quests.InMemory.Db.get_quest_by_id(quest_started.quest_id)
+    {:ok, quest} = PointQuest.quest_repo().get_quest_by_id(quest_started.quest_id)
 
     token =
       quest.party.party_leader
@@ -101,7 +101,7 @@ defmodule PointQuestWeb.QuestStartLive do
       |> StartQuest.new!()
       |> StartQuest.execute()
 
-    {:ok, quest} = Infra.Quests.InMemory.Db.get_quest_by_id(quest_started.quest_id)
+    {:ok, quest} = PointQuest.quest_repo().get_quest_by_id(quest_started.quest_id)
 
     token =
       quest.party.party_leader

--- a/test/support/quest_setup_helper.ex
+++ b/test/support/quest_setup_helper.ex
@@ -12,7 +12,7 @@ defmodule QuestSetupHelper do
       |> StartQuest.execute()
 
     {:ok, %{party: %{party_leader: party_leader}} = quest} =
-      Infra.Quests.InMemory.Db.get_quest_by_id(quest_started.quest_id)
+      PointQuest.quest_repo().get_quest_by_id(quest_started.quest_id)
 
     {:ok, quest_started} =
       StartQuest.new!(%{
@@ -20,7 +20,7 @@ defmodule QuestSetupHelper do
       })
       |> StartQuest.execute()
 
-    {:ok, other_quest} = Infra.Quests.InMemory.Db.get_quest_by_id(quest_started.quest_id)
+    {:ok, other_quest} = PointQuest.quest_repo().get_quest_by_id(quest_started.quest_id)
 
     {:ok, %{id: adventurer_id}} =
       AddAdventurer.new!(%{name: "Sir Stephen Bolton", class: :knight, quest_id: quest.id})


### PR DESCRIPTION
This implementation is for testing purposes. It will give us a way to run the business rule tests without needing to mock the data layer since it is pure and in memory. This simple in memory store doesn't have any sort of auto kill or snapshotting.

Closes: PQ-129