### PR TITLE
feat: add list of objectives to quest

### DIFF
--- a/lib/infra/quests/event_handler.ex
+++ b/lib/infra/quests/event_handler.ex
@@ -10,6 +10,7 @@ defmodule Infra.Quests.EventHandler do
       __MODULE__,
       [
         attack(:stop),
+        add_objective(:stop),
         round_started(:stop),
         round_ended(:stop)
       ],

--- a/lib/point_quest/quests/commands/add_simple_objective.ex
+++ b/lib/point_quest/quests/commands/add_simple_objective.ex
@@ -1,0 +1,60 @@
+defmodule PointQuest.Quests.Commands.AddSimpleObjective do
+  @moduledoc """
+  Command for a party leader to add a simple objective to the quest.
+  """
+  use PointQuest.Valuable
+
+  alias PointQuest.Quests
+  alias PointQuest.Quests.Objectives.Objective
+
+  require PointQuest.Quests.Telemetry
+  require Telemetrex
+
+  @type t :: %__MODULE__{
+          quest_id: String.t(),
+          quest_objective: String.t()
+        }
+
+  @primary_key false
+  embedded_schema do
+    field :quest_id, :string
+    field :quest_objective, :string
+  end
+
+  @spec execute(add_objective_command :: t(), actor :: Authentication.PartyLeader.t()) ::
+          {:ok, Quests.Event.ObjectiveAdded.t()}
+  def execute(add_objective_command, actor) do
+    Telemetrex.span event: Quests.Telemetry.add_objective(),
+                    context: %{command: add_objective_command, actor: actor} do
+      with {:ok, quest} <-
+             PointQuest.quest_repo().get_quest_by_id(add_objective_command.quest_id),
+           true <- can_add_objective(quest, actor),
+           {:ok, event} <- Quests.Quest.handle(add_objective_command, quest),
+           {:ok, _quest} <- PointQuest.quest_repo().write(quest, event) do
+        {:ok, event}
+      else
+        false -> {:error, :must_be_leader_of_party}
+        {:error, _error} = error -> error
+      end
+    after
+      {:ok, event} -> %{event: event}
+      {:error, reason} -> %{error: true, reason: reason}
+    end
+  end
+
+  defp can_add_objective(quest, actor) do
+    [
+      Quests.Spec.is_party_leader?(quest, actor)
+    ]
+    |> Enum.any?()
+  end
+
+  defimpl PointQuest.Quests.Objectives.Questable do
+    def to_objective(add_objective_command) do
+      Objective.changeset(%Objective{}, %{
+        id: add_objective_command.quest_objective
+      })
+      |> Ecto.Changeset.apply_action!(:insert)
+    end
+  end
+end

--- a/lib/point_quest/quests/events/objective_added.ex
+++ b/lib/point_quest/quests/events/objective_added.ex
@@ -1,0 +1,14 @@
+defmodule PointQuest.Quests.Event.ObjectiveAdded do
+  @moduledoc """
+  Update a quest to add a new objective.
+  """
+  use PointQuest.Valuable
+
+  alias PointQuest.Quests.Objectives.Objective
+
+  @primary_key false
+  embedded_schema do
+    field :quest_id, :string
+    embeds_one :objective, Objective
+  end
+end

--- a/lib/point_quest/quests/objectives/objective.ex
+++ b/lib/point_quest/quests/objectives/objective.ex
@@ -1,0 +1,28 @@
+defmodule PointQuest.Quests.Objectives.Objective do
+  @moduledoc """
+  Object that all external issue types should map to.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          title: String.t() | nil,
+          description: String.t() | nil
+        }
+
+  @primary_key false
+  embedded_schema do
+    field :id, :string
+    field :title, :string
+    field :description, :string
+  end
+
+  def changeset(issue, params \\ %{}) do
+    issue
+    |> cast(params, [:id, :title, :description])
+    |> validate_required([:id])
+  end
+end

--- a/lib/point_quest/quests/objectives/questable.ex
+++ b/lib/point_quest/quests/objectives/questable.ex
@@ -1,0 +1,6 @@
+defprotocol PointQuest.Quests.Objectives.Questable do
+  alias PointQuest.Quests.Objectives.Objective
+
+  @spec to_objective(any()) :: Objective.t()
+  def to_objective(issue)
+end

--- a/lib/point_quest/quests/telemetry.ex
+++ b/lib/point_quest/quests/telemetry.ex
@@ -9,6 +9,7 @@ defmodule PointQuest.Quests.Telemetry do
 
   defevent(:attack, @prefix ++ [:attack])
   defevent(:add_adventurer, @prefix ++ [:add_adventurer])
+  defevent(:add_objective, @prefix ++ [:add_objective])
   defevent(:quest_started, @prefix ++ [:quest_started])
   defevent(:round_started, @prefix ++ [:round_started])
   defevent(:round_ended, @prefix ++ [:round_ended])

--- a/test/point_quest/quests/commands/add_simple_objective_test.exs
+++ b/test/point_quest/quests/commands/add_simple_objective_test.exs
@@ -1,0 +1,72 @@
+defmodule PointQuest.Quests.Commands.AddSimpleObjectiveTest do
+  use ExUnit.Case
+
+  alias PointQuest.Error
+  alias PointQuest.Quests.Commands.AddSimpleObjective
+  alias PointQuest.Quests.Objectives.Objective
+  alias PointQuest.Quests.Objectives.Questable
+
+  setup do
+    {:ok, QuestSetupHelper.setup()}
+  end
+
+  # `changeset/2`, `new/1`, and `new!/1` are all implemented from the
+  # `Valuable` macro, and are not overridden in our command. As such
+  # I have opted not to test them here as we have other unit tests
+  # proving the functionality of the macro implementations.
+
+  describe "execute/2" do
+    test "returns objective_added event on success", %{
+      quest: %{id: quest_id},
+      party_leader_actor: actor
+    } do
+      Phoenix.PubSub.subscribe(PointQuestWeb.PubSub, quest_id)
+
+      quest_objective =
+        Objective.changeset(%Objective{}, %{id: "make the test pass"})
+        |> Ecto.Changeset.apply_action!(:insert)
+
+      objective_added_event = %PointQuest.Quests.Event.ObjectiveAdded{
+        quest_id: quest_id,
+        objective: quest_objective
+      }
+
+      assert {:ok, ^objective_added_event} =
+               %{quest_id: quest_id, quest_objective: "make the test pass"}
+               |> AddSimpleObjective.new!()
+               |> AddSimpleObjective.execute(actor)
+
+      assert_received ^objective_added_event
+    end
+
+    test "fails if quest ID doesn't exist", %{party_leader_actor: actor} do
+      error = Error.NotFound.exception(resource: :quest)
+
+      assert {:error, ^error} =
+               AddSimpleObjective.new!(%{quest_id: "McLovin", quest_objective: "make test fail"})
+               |> AddSimpleObjective.execute(actor)
+    end
+
+    test "fails if objective is not added by party leader", %{
+      quest: %{id: quest_id},
+      adventurer_actor: actor
+    } do
+      assert {:error, :must_be_leader_of_party} =
+               AddSimpleObjective.new!(%{quest_id: quest_id, quest_objective: "fail AGAIN!"})
+               |> AddSimpleObjective.execute(actor)
+    end
+  end
+
+  test "to_objective/1 returns objective from add_objective command", %{quest: %{id: quest_id}} do
+    objective = "test protocol implementation"
+
+    command =
+      AddSimpleObjective.new!(%{
+        quest_id: quest_id,
+        quest_objective: objective
+      })
+
+    assert %Objective{id: ^objective, title: nil, description: nil} =
+             Questable.to_objective(command)
+  end
+end


### PR DESCRIPTION
Quests should be able to contain multiple objectives in a list instead of needing to add a new objective for each round. This sets us up with a `SimpleObjective` model which matches our current state of just providing a simple string to the Party Leader in order to display on the quest page.

Currently this is a backend-only change. The quest page will still make a single objective per round, and I intend to switch over to the objective list and remove the singular `objective` field in a future PR.