### PR TITLE
fix: handle adventurer ids when joining a party

### DIFF
--- a/lib/point_quest/quests/events/adventurer_joined_party.ex
+++ b/lib/point_quest/quests/events/adventurer_joined_party.ex
@@ -2,8 +2,10 @@ defmodule PointQuest.Quests.Event.AdventurerJoinedParty do
   use PointQuest.Valuable
   alias PointQuest.Quests.Adventurer
 
+  @primary_key false
   embedded_schema do
     field :quest_id
+    field :adventurer_id
     field :name
     field :class, Adventurer.Class.NameEnum
   end
@@ -11,7 +13,7 @@ defmodule PointQuest.Quests.Event.AdventurerJoinedParty do
   def changeset(adventurer_joined, params \\ %{}) do
     adventurer_joined
     |> cast(params, [:quest_id, :name, :class])
-    |> change(id: Nanoid.generate_non_secure())
+    |> change(adventurer_id: Nanoid.generate_non_secure())
     |> validate_required([:quest_id, :name])
   end
 end

--- a/lib/point_quest/quests/quest.ex
+++ b/lib/point_quest/quests/quest.ex
@@ -84,7 +84,7 @@ defmodule PointQuest.Quests.Quest do
     adventurer =
       %Quests.Adventurer{}
       |> Adventurer.create_changeset(%{
-        id: event.id,
+        id: event.adventurer_id,
         name: event.name,
         class: event.class,
         quest_id: event.quest_id

--- a/lib/point_quest_web/live/quest_join.ex
+++ b/lib/point_quest_web/live/quest_join.ex
@@ -64,7 +64,7 @@ defmodule PointQuestWeb.QuestJoinLive do
       |> AddAdventurer.execute()
 
     {:ok, adventurer} =
-      %{quest_id: socket.assigns.quest.id, adventurer_id: adventurer_added.id}
+      %{quest_id: socket.assigns.quest.id, adventurer_id: adventurer_added.adventurer_id}
       |> GetAdventurer.new!()
       |> GetAdventurer.execute()
 

--- a/test/point_quest/quests/quest_test.exs
+++ b/test/point_quest/quests/quest_test.exs
@@ -92,7 +92,7 @@ defmodule PointQuest.Quests.QuestTest do
       assert Enum.member?(adventurers, %Quests.Adventurer{
                name: event.name,
                class: event.class,
-               id: event.id,
+               id: event.adventurer_id,
                quest_id: event.quest_id
              })
     end

--- a/test/support/quest_setup_helper.ex
+++ b/test/support/quest_setup_helper.ex
@@ -22,7 +22,7 @@ defmodule QuestSetupHelper do
 
     {:ok, other_quest} = PointQuest.quest_repo().get_quest_by_id(quest_started.quest_id)
 
-    {:ok, %{id: adventurer_id}} =
+    {:ok, %{adventurer_id: adventurer_id}} =
       AddAdventurer.new!(%{name: "Sir Stephen Bolton", class: :knight, quest_id: quest.id})
       |> AddAdventurer.execute()
 


### PR DESCRIPTION
We were using the event id to be the id of the attacker once they joined. In couch land couch controls the event ids ans their id was winning out. To match patterns we have done elsewhere I went with having the attacker id be an explicit value on the event rather than the id for the event.

Closes: PQ-131