### PR TITLE
refactor: remove quest return from db behaviour

### DIFF
--- a/lib/infra/quests/couch/db.ex
+++ b/lib/infra/quests/couch/db.ex
@@ -8,25 +8,23 @@ defmodule Infra.Quests.Couch.Db do
 
   @impl PointQuest.Behaviour.Quests.Repo
   def write(_init_quest, %Event.QuestStarted{} = event) do
-    Couch.Client.put(
-      "/events/quest-#{event.quest_id}:#{ExULID.ULID.generate()}",
-      Couch.Document.to_doc(event)
-    )
-    |> case do
-      {:ok, _body} ->
-        get_quest_by_id(event.quest_id)
-    end
+    {:ok, _doc} =
+      Couch.Client.put(
+        "/events/quest-#{event.quest_id}:#{ExULID.ULID.generate()}",
+        Couch.Document.to_doc(event)
+      )
+
+    :ok
   end
 
   def write(quest, event) do
-    Couch.Client.put(
-      "/events/quest-#{quest.id}:#{ExULID.ULID.generate()}",
-      Couch.Document.to_doc(event)
-    )
-    |> case do
-      {:ok, _body} ->
-        get_quest_by_id(quest.id)
-    end
+    {:ok, _doc} =
+      Couch.Client.put(
+        "/events/quest-#{quest.id}:#{ExULID.ULID.generate()}",
+        Couch.Document.to_doc(event)
+      )
+
+    :ok
   end
 
   @impl PointQuest.Behaviour.Quests.Repo

--- a/lib/infra/quests/in_memory/db.ex
+++ b/lib/infra/quests/in_memory/db.ex
@@ -19,14 +19,13 @@ defmodule Infra.Quests.InMemory.Db do
       )
 
     _event = InMemory.QuestServer.add_event(pid, event)
-    new_quest = Projectionist.Store.get(InMemory.QuestStore, event.quest_id)
 
-    {:ok, new_quest}
+    :ok
   end
 
   def write(quest, event) do
     InMemory.QuestServer.add_event({:via, Horde.Registry, {InMemory.Registry, quest.id}}, event)
-    {:ok, Projectionist.Store.get(InMemory.QuestStore, quest.id)}
+    :ok
   end
 
   @impl PointQuest.Behaviour.Quests.Repo

--- a/lib/infra/quests/simple_in_memory/db.ex
+++ b/lib/infra/quests/simple_in_memory/db.ex
@@ -14,9 +14,7 @@ defmodule Infra.Quests.SimpleInMemory.Db do
       )
 
     _event = SimpleInMemory.EventServer.add_event(pid, event)
-    new_quest = SimpleInMemory.EventServer.get_quest(pid)
-
-    {:ok, new_quest}
+    :ok
   end
 
   def write(quest, event) do
@@ -27,9 +25,7 @@ defmodule Infra.Quests.SimpleInMemory.Db do
       event
     )
 
-    new_quest = SimpleInMemory.EventServer.get_quest(event_store)
-
-    {:ok, new_quest}
+    :ok
   end
 
   @impl PointQuest.Behaviour.Quests.Repo

--- a/lib/point_quest/behaviour/quests/repo.ex
+++ b/lib/point_quest/behaviour/quests/repo.ex
@@ -3,7 +3,7 @@ defmodule PointQuest.Behaviour.Quests.Repo do
   alias PointQuest.Quests
   alias PointQuest.Quests.Event
 
-  @callback write(Quests.Quest.t(), Event.QuestStarted.t()) :: {:ok, Quest.t()}
+  @callback write(Quests.Quest.t(), Event.QuestStarted.t()) :: :ok
   @callback get_quest_by_id(quest_id :: String.t()) ::
               {:ok, Quests.Quest.t()} | {:error, Error.NotFound.t(:quest)}
   @callback get_adventurer_by_id(quest_id :: String.t(), adventurer_id :: String.t()) ::

--- a/lib/point_quest/quests/commands/add_adventurer.ex
+++ b/lib/point_quest/quests/commands/add_adventurer.ex
@@ -111,7 +111,7 @@ defmodule PointQuest.Quests.Commands.AddAdventurer do
                     context: %{command: add_adventurer_command} do
       with {:ok, quest} <- PointQuest.quest_repo().get_quest_by_id(quest_id),
            {:ok, event} <- Quests.Quest.handle(add_adventurer_command, quest),
-           {:ok, _quest} <-
+           :ok <-
              PointQuest.quest_repo().write(
                quest,
                event

--- a/lib/point_quest/quests/commands/add_simple_objective.ex
+++ b/lib/point_quest/quests/commands/add_simple_objective.ex
@@ -30,7 +30,7 @@ defmodule PointQuest.Quests.Commands.AddSimpleObjective do
              PointQuest.quest_repo().get_quest_by_id(add_objective_command.quest_id),
            true <- can_add_objective(quest, actor),
            {:ok, event} <- Quests.Quest.handle(add_objective_command, quest),
-           {:ok, _quest} <- PointQuest.quest_repo().write(quest, event) do
+           :ok <- PointQuest.quest_repo().write(quest, event) do
         {:ok, event}
       else
         false -> {:error, :must_be_leader_of_party}

--- a/lib/point_quest/quests/commands/attack.ex
+++ b/lib/point_quest/quests/commands/attack.ex
@@ -36,7 +36,7 @@ defmodule PointQuest.Quests.Commands.Attack do
              ),
            true <- can_attack?(adventurer, quest, actor),
            {:ok, event} <- Quests.Quest.handle(attack_command, quest),
-           {:ok, _quest} <- PointQuest.quest_repo().write(quest, event) do
+           :ok <- PointQuest.quest_repo().write(quest, event) do
         {:ok, event}
       else
         false ->

--- a/lib/point_quest/quests/commands/start_quest.ex
+++ b/lib/point_quest/quests/commands/start_quest.ex
@@ -100,7 +100,7 @@ defmodule PointQuest.Quests.Commands.StartQuest do
     Telemetrex.span event: Quests.Telemetry.quest_started(),
                     context: %{command: start_quest_command} do
       with {:ok, event} <- Quests.Quest.handle(start_quest_command, quest),
-           {:ok, _quest} <- PointQuest.quest_repo().write(quest, event) do
+           :ok <- PointQuest.quest_repo().write(quest, event) do
         {:ok, event}
       end
     after

--- a/lib/point_quest/quests/commands/start_round.ex
+++ b/lib/point_quest/quests/commands/start_round.ex
@@ -40,7 +40,7 @@ defmodule PointQuest.Quests.Commands.StartRound do
       with {:ok, quest} <- PointQuest.quest_repo().get_quest_by_id(start_round_command.quest_id),
            true <- can_start_round?(quest, actor),
            {:ok, event} <- Quests.Quest.handle(start_round_command, quest),
-           {:ok, _quest} <- PointQuest.quest_repo().write(quest, event) do
+           :ok <- PointQuest.quest_repo().write(quest, event) do
         {:ok, event}
       else
         false -> {:error, :must_be_leader_of_quest_party}

--- a/lib/point_quest/quests/commands/stop_round.ex
+++ b/lib/point_quest/quests/commands/stop_round.ex
@@ -38,7 +38,7 @@ defmodule PointQuest.Quests.Commands.StopRound do
       with {:ok, quest} <- PointQuest.quest_repo().get_quest_by_id(stop_round_command.quest_id),
            true <- can_stop_round?(quest, actor),
            {:ok, event} <- Quests.Quest.handle(stop_round_command, quest),
-           {:ok, _quest} <- PointQuest.quest_repo().write(quest, event) do
+           :ok <- PointQuest.quest_repo().write(quest, event) do
         {:ok, event}
       else
         false -> {:error, :must_be_leader_of_quest_party}


### PR DESCRIPTION
None of the commands were leveraging the fact that the repo modules were returning a quest object. This was leading to an extra quest call per action on the system.

Closes: PQ-132