### PR TITLE
feat: iterate through objective list per round

### DIFF
--- a/lib/point_quest/quests/commands/start_round.ex
+++ b/lib/point_quest/quests/commands/start_round.ex
@@ -5,7 +5,7 @@ defmodule PointQuest.Quests.Commands.StartRound do
   Ensure that you're calling either `new/1` or `new!/1` followed by `execute/1` in order to
   update the quest.
   """
-  use PointQuest.Valuable, optional_fields: [:quest_objective]
+  use PointQuest.Valuable
 
   alias PointQuest.Quests
   alias PointQuest.Authentication
@@ -14,14 +14,12 @@ defmodule PointQuest.Quests.Commands.StartRound do
   require Telemetrex
 
   @type t :: %__MODULE__{
-          quest_id: String.t(),
-          quest_objective: String.t()
+          quest_id: String.t()
         }
 
   @primary_key false
   embedded_schema do
     field :quest_id, :string
-    field :quest_objective, :string
   end
 
   @spec execute(start_round_command :: t(), actor :: Authentication.PartyLeader.t()) ::

--- a/lib/point_quest/quests/events/round_ended.ex
+++ b/lib/point_quest/quests/events/round_ended.ex
@@ -2,10 +2,13 @@ defmodule PointQuest.Quests.Event.RoundEnded do
   @moduledoc """
   Updates a quest to end the current round.
   """
-  use PointQuest.Valuable
+  use PointQuest.Valuable, optional_fields: [:objectives]
+
+  alias PointQuest.Quests.Objectives.Objective
 
   @primary_key false
   embedded_schema do
     field :quest_id, :string
+    embeds_many :objectives, Objective
   end
 end

--- a/lib/point_quest/quests/events/round_started.ex
+++ b/lib/point_quest/quests/events/round_started.ex
@@ -2,28 +2,13 @@ defmodule PointQuest.Quests.Event.RoundStarted do
   @moduledoc """
   Update a quest to start a new round.
   """
-  use PointQuest.Valuable
+  use PointQuest.Valuable, optional_fields: [:objectives]
+
+  alias PointQuest.Quests.Objectives.Objective
 
   @primary_key false
   embedded_schema do
     field :quest_id, :string
-    field :quest_objective, :string
-  end
-
-  def changeset(round_started, params \\ %{}) do
-    round_started
-    |> cast(params, [:quest_id, :quest_objective])
-    |> default_quest_objective()
-  end
-
-  def default_quest_objective(%Ecto.Changeset{valid?: false} = invalid_changeset),
-    do: invalid_changeset
-
-  def default_quest_objective(changeset) do
-    if get_change(changeset, :quest_objective) != nil do
-      changeset
-    else
-      put_change(changeset, :quest_objective, "")
-    end
+    embeds_many :objectives, Objective
   end
 end

--- a/test/point_quest/quests/commands/start_round_test.exs
+++ b/test/point_quest/quests/commands/start_round_test.exs
@@ -12,12 +12,7 @@ defmodule PointQuest.Quests.Commands.StartRoundTest do
 
   describe "new/1" do
     test "returns ok tuple if valid", %{quest: %{id: quest_id}} do
-      assert {:ok, %StartRound{quest_id: ^quest_id, quest_objective: "https://www.google.com"}} =
-               StartRound.new(%{quest_id: quest_id, quest_objective: "https://www.google.com"})
-    end
-
-    test "quest_objective is optional", %{quest: %{id: quest_id}} do
-      assert {:ok, %StartRound{quest_id: ^quest_id, quest_objective: nil}} =
+      assert {:ok, %StartRound{quest_id: ^quest_id}} =
                StartRound.new(%{quest_id: quest_id})
     end
 
@@ -66,7 +61,7 @@ defmodule PointQuest.Quests.Commands.StartRoundTest do
         )
 
       assert {:ok, %RoundStarted{} = round_started} =
-               %{quest_id: quest.id, quest_objective: "https://bitsonthemind.com"}
+               %{quest_id: quest.id}
                |> StartRound.new!()
                |> StartRound.execute(actor)
 


### PR DESCRIPTION
When we start a round, the next incomplete objective should move to be the current objective.

When we stop a round, the current objective should move to complete.