### PR TITLE
fix: use sort_order instead of sort_value

### DIFF
--- a/lib/point_quest/quests/commands/sort_objective.ex
+++ b/lib/point_quest/quests/commands/sort_objective.ex
@@ -12,14 +12,14 @@ defmodule PointQuest.Quests.Commands.SortObjective do
   @type t :: %__MODULE__{
           quest_id: String.t(),
           objective_id: String.t(),
-          sort_value: float()
+          sort_order: float()
         }
 
   @primary_key false
   embedded_schema do
     field :quest_id, :string
     field :objective_id, :string
-    field :sort_value, :float
+    field :sort_order, :float
   end
 
   @spec execute(t(), PointQuest.Authentication.Actor.t()) ::

--- a/lib/point_quest/quests/quest.ex
+++ b/lib/point_quest/quests/quest.ex
@@ -256,7 +256,7 @@ defmodule PointQuest.Quests.Quest do
       quest.objectives
       |> Enum.reduce([], fn o, acc ->
         if o.id == command.objective_id do
-          [%{o | sort_order: command.sort_value} | acc]
+          [%{o | sort_order: command.sort_order} | acc]
         else
           [o | acc]
         end

--- a/lib/point_quest_web/live/quest.ex
+++ b/lib/point_quest_web/live/quest.ex
@@ -322,13 +322,13 @@ defmodule PointQuestWeb.QuestLive do
     ending_index = length(objectives) - 1
     updated_objective = Enum.at(objectives, old_index)
 
-    sort_value =
+    sort_order =
       case new_index do
         0 ->
-          hd(objectives).sort_value - 0.001
+          hd(objectives).sort_order - 0.001
 
         ^ending_index ->
-          List.last(objectives).sort_value + 0.001
+          List.last(objectives).sort_order + 0.001
 
         index ->
           floor = Enum.at(objectives, index - 1)
@@ -339,7 +339,7 @@ defmodule PointQuestWeb.QuestLive do
     Commands.SortObjective.new!(%{
       quest_id: socket.assigns.quest.id,
       objective_id: updated_objective.id,
-      sort_value: sort_value
+      sort_order: sort_order
     })
     |> Commands.SortObjective.execute(socket.assigns.actor)
 

--- a/test/point_quest/quests/commands/sort_objective_test.exs
+++ b/test/point_quest/quests/commands/sort_objective_test.exs
@@ -30,7 +30,7 @@ defmodule PointQuest.Quests.Commands.SortObjectiveTest do
     %{id: objective_id} = moving_objective = List.last(objectives)
     sorted_objective = %{moving_objective | sort_order: first.sort_order - 0.01}
 
-    %{quest_id: quest_id, objective_id: objective_id, sort_value: first.sort_order - 0.01}
+    %{quest_id: quest_id, objective_id: objective_id, sort_order: first.sort_order - 0.01}
     |> SortObjective.new!()
     |> SortObjective.execute(actor)
 
@@ -60,7 +60,7 @@ defmodule PointQuest.Quests.Commands.SortObjectiveTest do
     last = List.last(objectives)
     sorted_objective = %{moving_objective | sort_order: last.sort_order + 0.01}
 
-    %{quest_id: quest_id, objective_id: objective_id, sort_value: last.sort_order + 0.01}
+    %{quest_id: quest_id, objective_id: objective_id, sort_order: last.sort_order + 0.01}
     |> SortObjective.new!()
     |> SortObjective.execute(actor)
 
@@ -103,7 +103,7 @@ defmodule PointQuest.Quests.Commands.SortObjectiveTest do
     %{
       quest_id: quest_id,
       objective_id: objective_id,
-      sort_value: (first.sort_order + middle.sort_order) / 2
+      sort_order: (first.sort_order + middle.sort_order) / 2
     }
     |> SortObjective.new!()
     |> SortObjective.execute(actor)


### PR DESCRIPTION
I introduced a partial refactor that changed the `sort_value` field to `sort_order`, but did not consistently apply it throughout the LiveView, commands, and tests.

This should resolve that issue in code quality, while also resolving the bug that was introduced due to that incomplete refactor.