### PR TITLE
feat: hide objective list for non-party leader

### DIFF
--- a/lib/point_quest_web/live/quest.ex
+++ b/lib/point_quest_web/live/quest.ex
@@ -16,7 +16,7 @@ defmodule PointQuestWeb.QuestLive do
   def render(assigns) do
     ~H"""
     <div id="top-level-wrapper" class="w-full flex mb-5">
-      <div id="objectives" class="w-1/5 mr-5">
+      <div :if={is_party_leader?(@actor)} id="objectives" class="w-1/5 mr-5">
         <div class="pb-5 w-full">
           <div id="sortable-list" phx-hook="Sortable" class="shadow-sm">
             <div


### PR DESCRIPTION
The objective list can only be interacted with by the party leader, and takes up screen real estate that doesn't really serve much purpose to the non-party leader adventurers.

This will hide the objective list (including the "create new objective" button) from adventurers (except the party-leader).