### PR TITLE
feat: add command for removing an adventurer

### DIFF
--- a/lib/infra/couch/document.ex
+++ b/lib/infra/couch/document.ex
@@ -47,6 +47,7 @@ defmodule Infra.Couch.Document do
   defp document_type_for(%Event.QuestStarted{}), do: "quest_started"
   defp document_type_for(%Event.AdventurerJoinedParty{}), do: "adventurer_joined_party"
   defp document_type_for(%Event.AdventurerAttacked{}), do: "adventurer_attacked"
+  defp document_type_for(%Event.AdventurerRemovedFromParty{}), do: "adventurer_removed"
   defp document_type_for(%Event.ObjectiveAdded{}), do: "objective_added"
   defp document_type_for(%Event.ObjectiveSorted{}), do: "objective_sorted"
   defp document_type_for(%Event.RoundStarted{}), do: "round_started"
@@ -55,6 +56,7 @@ defmodule Infra.Couch.Document do
   defp type_from_document("quest_started"), do: Event.QuestStarted
   defp type_from_document("adventurer_joined_party"), do: Event.AdventurerJoinedParty
   defp type_from_document("adventurer_attacked"), do: Event.AdventurerAttacked
+  defp type_from_document("adventurer_removed"), do: Event.AdventurerRemovedFromParty
   defp type_from_document("objective_added"), do: Event.ObjectiveAdded
   defp type_from_document("objective_sorted"), do: Event.ObjectiveSorted
   defp type_from_document("round_started"), do: Event.RoundStarted

--- a/lib/infra/quests/event_handler.ex
+++ b/lib/infra/quests/event_handler.ex
@@ -12,6 +12,7 @@ defmodule Infra.Quests.EventHandler do
         attack(:stop),
         add_objective(:stop),
         objective_sorted(:stop),
+        remove_adventurer(:stop),
         round_started(:stop),
         round_ended(:stop)
       ],

--- a/lib/point_quest/quests/commands/remove_adventurer.ex
+++ b/lib/point_quest/quests/commands/remove_adventurer.ex
@@ -1,0 +1,73 @@
+defmodule PointQuest.Quests.Commands.RemoveAdventurer do
+  @moduledoc """
+  Command to remove an adventurer from a quest.
+  """
+  use PointQuest.Valuable
+
+  alias PointQuest.Authentication.Actor
+  alias PointQuest.Quests
+
+  require PointQuest.Quests.Telemetry
+  require Telemetrex
+
+  @type t :: %__MODULE__{
+          adventurer_id: String.t(),
+          quest_id: String.t()
+        }
+
+  @primary_key false
+  embedded_schema do
+    field :adventurer_id, :string
+    field :quest_id, :string
+  end
+
+  @spec changeset(t(), map()) :: Ecto.Changeset.t(t())
+  @doc """
+  Creates a changeset from remove_adventurer struct and params.
+  """
+  def changeset(remove_adventurer, params) do
+    remove_adventurer
+    |> cast(params, [:adventurer_id, :quest_id])
+    |> validate_required([:adventurer_id, :quest_id])
+  end
+
+  @spec execute(t(), Actor.t()) ::
+          {:ok, PointQuest.Quests.Event.AdventurerRemovedFromParty.t()} | {:error, String.t()}
+  @doc """
+  Executes the command to update the quest state.
+
+  Returns the event for removing an adventurer.
+  """
+  def execute(%__MODULE__{quest_id: quest_id} = remove_adventurer_command, actor) do
+    Telemetrex.span event: Quests.Telemetry.remove_adventurer(),
+                    context: %{command: remove_adventurer_command, actor: actor} do
+      with {:ok, quest} <- PointQuest.quest_repo().get_quest_by_id(quest_id),
+           {:ok, adventurer} <-
+             PointQuest.quest_repo().get_adventurer_by_id(
+               quest_id,
+               remove_adventurer_command.adventurer_id
+             ),
+           true <- can_remove_adventurer?(adventurer, quest, actor),
+           {:ok, event} <- Quests.Quest.handle(remove_adventurer_command, quest),
+           :ok <-
+             PointQuest.quest_repo().write(quest, event) do
+        {:ok, event}
+      else
+        false ->
+          {:error, "not authorized to remove adventurer"}
+      end
+    after
+      {:ok, event} -> %{event: event}
+      {:error, reason} -> %{error: true, reason: reason}
+    end
+  end
+
+  defp can_remove_adventurer?(adventurer, quest, actor) do
+    [
+      Quests.Spec.actor_is_target?(adventurer, actor),
+      Quests.Spec.is_in_party?(quest, actor),
+      Quests.Spec.is_party_leader?(quest, actor)
+    ]
+    |> Enum.any?()
+  end
+end

--- a/lib/point_quest/quests/events/adventurer_removed_from_party.ex
+++ b/lib/point_quest/quests/events/adventurer_removed_from_party.ex
@@ -1,0 +1,15 @@
+defmodule PointQuest.Quests.Event.AdventurerRemovedFromParty do
+  use PointQuest.Valuable
+
+  @primary_key false
+  embedded_schema do
+    field :quest_id
+    field :adventurer_id
+  end
+
+  def changeset(adventurer_removed, params \\ %{}) do
+    adventurer_removed
+    |> cast(params, [:quest_id, :adventurer_id])
+    |> validate_required([:quest_id, :adventurer_id])
+  end
+end

--- a/lib/point_quest/quests/quest.ex
+++ b/lib/point_quest/quests/quest.ex
@@ -100,6 +100,18 @@ defmodule PointQuest.Quests.Quest do
     }
   end
 
+  def project(%Event.AdventurerRemovedFromParty{} = event, quest) do
+    adventurers = Enum.reject(quest.party.adventurers, fn a -> a.id == event.adventurer_id end)
+
+    %__MODULE__{
+      quest
+      | party: %PointQuest.Quests.Party{
+          quest.party
+          | adventurers: adventurers
+        }
+    }
+  end
+
   def project(%Event.AdventurerAttacked{} = command, %__MODULE__{attacks: attacks} = quest) do
     # adventurer could be updating their previous attack
     updated_attacks =
@@ -178,6 +190,10 @@ defmodule PointQuest.Quests.Quest do
     else
       {:ok, Event.AdventurerJoinedParty.new!(Ecto.embedded_dump(command, :json))}
     end
+  end
+
+  def handle(%Commands.RemoveAdventurer{} = command, _quest) do
+    {:ok, Event.AdventurerRemovedFromParty.new!(Ecto.embedded_dump(command, :json))}
   end
 
   def handle(%Commands.Attack{} = command, _quest) do

--- a/lib/point_quest/quests/spec.ex
+++ b/lib/point_quest/quests/spec.ex
@@ -19,27 +19,32 @@ defmodule PointQuest.Quests.Spec do
   @doc """
   Ensure the provided attacker id is the actor
   """
-  def is_attacker?(_attacker, %Actor.PartyLeader{adventurer: nil}), do: false
+  def is_attacker?(attacker, actor), do: actor_is_target?(attacker, actor)
 
-  def is_attacker?(%Adventurer{id: attacker_id}, %Actor.PartyLeader{
-        adventurer: %{id: attacker_id}
+  @doc """
+  Ensure that the actor is targetting themselves as an adventurer
+  """
+  def actor_is_target?(_target, %Actor.PartyLeader{adventurer: nil}), do: false
+
+  def actor_is_target?(%Adventurer{id: target_id}, %Actor.PartyLeader{
+        adventurer: %{id: target_id}
       }),
       do: true
 
-  def is_attacker?(%Adventurer{id: _attacker_id}, %Actor.PartyLeader{
+  def actor_is_target?(%Adventurer{id: _target_id}, %Actor.PartyLeader{
         adventurer: %{id: _other_adventurer}
       }),
       do: false
 
-  def is_attacker?(%Adventurer{id: attacker_id}, %Actor.Adventurer{adventurer: %{id: attacker_id}}),
+  def actor_is_target?(%Adventurer{id: target_id}, %Actor.Adventurer{adventurer: %{id: target_id}}),
       do: true
 
-  def is_attacker?(%Adventurer{id: _attacker_id}, %Actor.Adventurer{
+  def actor_is_target?(%Adventurer{id: _target_id}, %Actor.Adventurer{
         adventurer: %{id: _other_adventurer}
       }),
       do: false
 
-  def is_attacker?(nil, _actor), do: false
+  def actor_is_target?(nil, _actor), do: false
 
   @spec is_in_party?(quest :: Quest.t(), actor :: Actor.t()) :: boolean
   @doc """

--- a/lib/point_quest/quests/telemetry.ex
+++ b/lib/point_quest/quests/telemetry.ex
@@ -12,6 +12,7 @@ defmodule PointQuest.Quests.Telemetry do
   defevent(:add_objective, @prefix ++ [:add_objective])
   defevent(:objective_sorted, @prefix ++ [:objective_sorted])
   defevent(:quest_started, @prefix ++ [:quest_started])
+  defevent(:remove_adventurer, @prefix ++ [:remove_adventurer])
   defevent(:round_started, @prefix ++ [:round_started])
   defevent(:round_ended, @prefix ++ [:round_ended])
 end

--- a/test/point_quest/quests/spec_test.exs
+++ b/test/point_quest/quests/spec_test.exs
@@ -33,6 +33,32 @@ defmodule PointQuest.Quests.SpecTest do
     end
   end
 
+  describe "actor_is_target?/2" do
+    test "policy check succeeds if actor is the target adventurer", %{
+      adventurer_actor: adventurer,
+      other_actor: party_leader
+    } do
+      assert Spec.actor_is_target?(adventurer.adventurer, adventurer)
+      assert Spec.actor_is_target?(party_leader.adventurer, party_leader)
+    end
+
+    test "policy check fails if actor is not target", %{
+      adventurer: adventurer,
+      other_actor: other_actor
+    } do
+      refute Spec.actor_is_target?(adventurer, other_actor)
+    end
+
+    test "policy check fails if party leader with no adventurer attempts to target other adventurer",
+         %{party_leader_actor: actor, adventurer: adventurer} do
+      refute Spec.actor_is_target?(adventurer, actor)
+    end
+
+    test "policy check fails if nil target is provided", %{party_leader_actor: actor} do
+      refute Spec.actor_is_target?(nil, actor)
+    end
+  end
+
   describe "is_in_party?/2" do
     test "policy check succeeds if adventurer is in party", %{
       quest: quest,


### PR DESCRIPTION
Support the functionality for an adventurer to remove themselves from the party, or for the party leader to remove another adventurer (including themselves) from the party.

UI functionality and cleanup will be handled in follow-up ticket.