### PR TITLE
feat: add ui for project manager to remove a member

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2,6 +2,7 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 @import "components/button.css";
+@import "components/hover.css";
 
 /* This file is for your main application CSS */
 .logo {

--- a/assets/css/components/hover.css
+++ b/assets/css/components/hover.css
@@ -1,0 +1,7 @@
+*:has(>.visible-on-parent-hover):not(:hover)>.visible-on-parent-hover {
+  opacity: 0;
+}
+
+*:has(>*>.visible-on-grandparent-hover):not(:hover)>*>.visible-on-grandparent-hover {
+  opacity: 0;
+}

--- a/lib/point_quest_web/live/quest.ex
+++ b/lib/point_quest_web/live/quest.ex
@@ -230,7 +230,7 @@ defmodule PointQuestWeb.QuestLive do
 
   def render_adventurer_interaction_icons(assigns) do
     ~H"""
-    <div class="flex items-start">
+    <div class="flex items-start visible-on-parent-hover">
       <a
         phx-click="alert-adventurer"
         phx-value-adventurer-id={@adventurer}
@@ -238,6 +238,9 @@ defmodule PointQuestWeb.QuestLive do
         class="items-center"
       >
         <.icon name="hero-signal" />
+      </a>
+      <a phx-click="kick-adventurer" phx-value-adventurer-id={@adventurer} class="items-center">
+        <.icon name="hero-x-circle" class="text-red-500" />
       </a>
     </div>
     """
@@ -419,6 +422,13 @@ defmodule PointQuestWeb.QuestLive do
     Phoenix.PubSub.broadcast(PointQuestWeb.PubSub, socket.assigns.quest.id, event)
 
     {:noreply, put_flash(socket, :info, "#{name} notified")}
+  end
+
+  def handle_event("kick-adventurer", %{"adventurer-id" => id}, socket) do
+    Commands.RemoveAdventurer.new!(%{adventurer_id: id, quest_id: socket.assigns.quest.id})
+    |> Commands.RemoveAdventurer.execute(socket.assigns.actor)
+
+    {:noreply, socket}
   end
 
   def handle_info(%Phoenix.Socket.Broadcast{event: "presence_diff", payload: diff}, socket) do


### PR DESCRIPTION
Move the current controls (previously only alerting an adventurer) to only show on hover, and add a control to remove a member from the quest.

Known issues:

- Party leader's cannot remove themselves. Removing your adventurer as the party leader will remove them from the UI, but only until a refresh or the quest is re-queried, as the adventurer is still parsed from their party leader object and not the adventurer's list.

- Adventurer's that are removed end on an error page as we're not removing their session tokens currently.