### PR TITLE
refactor: return event with id from db write

### DIFF
--- a/lib/infra/quests/in_memory/db.ex
+++ b/lib/infra/quests/in_memory/db.ex
@@ -19,14 +19,12 @@ defmodule Infra.Quests.InMemory.Db do
         {InMemory.QuestServer, quest_id: event.quest_id}
       )
 
-    _event = InMemory.QuestServer.add_event(pid, event)
-
-    :ok
+    {:ok, InMemory.QuestServer.add_event(pid, event)}
   end
 
   def write(quest, event) do
-    InMemory.QuestServer.add_event({:via, Horde.Registry, {InMemory.Registry, quest.id}}, event)
-    :ok
+    {:ok,
+     InMemory.QuestServer.add_event({:via, Horde.Registry, {InMemory.Registry, quest.id}}, event)}
   end
 
   @impl PointQuest.Behaviour.Quests.Repo

--- a/lib/infra/quests/in_memory/quest_server.ex
+++ b/lib/infra/quests/in_memory/quest_server.ex
@@ -52,6 +52,7 @@ defmodule Infra.Quests.InMemory.QuestServer do
 
   def handle_call({:add_event, event}, _from, state) do
     :erlang.cancel_timer(state.timeout_ref)
+    event = Map.put(event, :id, Nanoid.generate())
     # new event gets added at the tail after possibly taking a new snapshot
     # doing this to optimize readers over writers (read doesn't need to enum reverse)
     state =

--- a/lib/infra/quests/simple_in_memory/db.ex
+++ b/lib/infra/quests/simple_in_memory/db.ex
@@ -13,19 +13,17 @@ defmodule Infra.Quests.SimpleInMemory.Db do
         {SimpleInMemory.EventServer, quest_id: event.quest_id}
       )
 
-    _event = SimpleInMemory.EventServer.add_event(pid, event)
-    :ok
+    {:ok, SimpleInMemory.EventServer.add_event(pid, event)}
   end
 
   def write(quest, event) do
     event_store = {:via, Registry, {SimpleInMemory.Registry, quest.id}}
 
-    SimpleInMemory.EventServer.add_event(
-      event_store,
-      event
-    )
-
-    :ok
+    {:ok,
+     SimpleInMemory.EventServer.add_event(
+       event_store,
+       event
+     )}
   end
 
   @impl PointQuest.Behaviour.Quests.Repo

--- a/lib/infra/quests/simple_in_memory/event_server.ex
+++ b/lib/infra/quests/simple_in_memory/event_server.ex
@@ -9,9 +9,13 @@ defmodule Infra.Quests.SimpleInMemory.EventServer do
   end
 
   def add_event(event_store, event) do
+    event = Map.put(event, :id, Nanoid.generate())
+
     Agent.update(event_store, fn events ->
       [event | events]
     end)
+
+    event
   end
 
   def get_quest(event_store) do

--- a/lib/point_quest/behaviour/quests/repo.ex
+++ b/lib/point_quest/behaviour/quests/repo.ex
@@ -1,9 +1,8 @@
 defmodule PointQuest.Behaviour.Quests.Repo do
   alias PointQuest.Error
   alias PointQuest.Quests
-  alias PointQuest.Quests.Event
 
-  @callback write(Quests.Quest.t(), Event.QuestStarted.t()) :: :ok
+  @callback write(Quests.Quest.t(), struct()) :: {:ok, struct()}
   @callback get_quest_by_id(quest_id :: String.t()) ::
               {:ok, Quests.Quest.t()} | {:error, Error.NotFound.t(:quest)}
   @callback get_adventurer_by_id(quest_id :: String.t(), adventurer_id :: String.t()) ::

--- a/lib/point_quest/quests/commands/add_adventurer.ex
+++ b/lib/point_quest/quests/commands/add_adventurer.ex
@@ -110,13 +110,11 @@ defmodule PointQuest.Quests.Commands.AddAdventurer do
     Telemetrex.span event: Quests.Telemetry.add_adventurer(),
                     context: %{command: add_adventurer_command} do
       with {:ok, quest} <- PointQuest.quest_repo().get_quest_by_id(quest_id),
-           {:ok, event} <- Quests.Quest.handle(add_adventurer_command, quest),
-           :ok <-
-             PointQuest.quest_repo().write(
-               quest,
-               event
-             ) do
-        {:ok, event}
+           {:ok, event} <- Quests.Quest.handle(add_adventurer_command, quest) do
+        PointQuest.quest_repo().write(
+          quest,
+          event
+        )
       end
     after
       {:ok, event} -> %{event: event}

--- a/lib/point_quest/quests/commands/add_simple_objective.ex
+++ b/lib/point_quest/quests/commands/add_simple_objective.ex
@@ -29,9 +29,8 @@ defmodule PointQuest.Quests.Commands.AddSimpleObjective do
       with {:ok, quest} <-
              PointQuest.quest_repo().get_quest_by_id(add_objective_command.quest_id),
            true <- can_add_objective(quest, actor),
-           {:ok, event} <- Quests.Quest.handle(add_objective_command, quest),
-           :ok <- PointQuest.quest_repo().write(quest, event) do
-        {:ok, event}
+           {:ok, event} <- Quests.Quest.handle(add_objective_command, quest) do
+        PointQuest.quest_repo().write(quest, event)
       else
         false -> {:error, :must_be_leader_of_party}
         {:error, _error} = error -> error

--- a/lib/point_quest/quests/commands/attack.ex
+++ b/lib/point_quest/quests/commands/attack.ex
@@ -35,9 +35,8 @@ defmodule PointQuest.Quests.Commands.Attack do
                })
              ),
            true <- can_attack?(adventurer, quest, actor),
-           {:ok, event} <- Quests.Quest.handle(attack_command, quest),
-           :ok <- PointQuest.quest_repo().write(quest, event) do
-        {:ok, event}
+           {:ok, event} <- Quests.Quest.handle(attack_command, quest) do
+        PointQuest.quest_repo().write(quest, event)
       else
         false ->
           {:error, "attack disallowed"}

--- a/lib/point_quest/quests/commands/remove_adventurer.ex
+++ b/lib/point_quest/quests/commands/remove_adventurer.ex
@@ -48,10 +48,8 @@ defmodule PointQuest.Quests.Commands.RemoveAdventurer do
                remove_adventurer_command.adventurer_id
              ),
            true <- can_remove_adventurer?(adventurer, quest, actor),
-           {:ok, event} <- Quests.Quest.handle(remove_adventurer_command, quest),
-           :ok <-
-             PointQuest.quest_repo().write(quest, event) do
-        {:ok, event}
+           {:ok, event} <- Quests.Quest.handle(remove_adventurer_command, quest) do
+        PointQuest.quest_repo().write(quest, event)
       else
         false ->
           {:error, "not authorized to remove adventurer"}

--- a/lib/point_quest/quests/commands/sort_objective.ex
+++ b/lib/point_quest/quests/commands/sort_objective.ex
@@ -29,9 +29,8 @@ defmodule PointQuest.Quests.Commands.SortObjective do
                     context: %{command: sort_objective_command, actor: actor} do
       with {:ok, quest} <- PointQuest.quest_repo().get_quest_by_id(quest_id),
            true <- can_sort?(quest, actor),
-           {:ok, event} <- Quests.Quest.handle(sort_objective_command, quest),
-           :ok <- PointQuest.quest_repo().write(quest, event) do
-        {:ok, event}
+           {:ok, event} <- Quests.Quest.handle(sort_objective_command, quest) do
+        PointQuest.quest_repo().write(quest, event)
       else
         false -> {:error, :must_be_leader_of_party}
         {:error, _error} = error -> error

--- a/lib/point_quest/quests/commands/start_quest.ex
+++ b/lib/point_quest/quests/commands/start_quest.ex
@@ -99,9 +99,8 @@ defmodule PointQuest.Quests.Commands.StartQuest do
 
     Telemetrex.span event: Quests.Telemetry.quest_started(),
                     context: %{command: start_quest_command} do
-      with {:ok, event} <- Quests.Quest.handle(start_quest_command, quest),
-           :ok <- PointQuest.quest_repo().write(quest, event) do
-        {:ok, event}
+      with {:ok, event} <- Quests.Quest.handle(start_quest_command, quest) do
+        PointQuest.quest_repo().write(quest, event)
       end
     after
       {:ok, event} -> %{event: event}

--- a/lib/point_quest/quests/commands/start_round.ex
+++ b/lib/point_quest/quests/commands/start_round.ex
@@ -37,9 +37,8 @@ defmodule PointQuest.Quests.Commands.StartRound do
                     context: %{command: start_round_command, actor: actor} do
       with {:ok, quest} <- PointQuest.quest_repo().get_quest_by_id(start_round_command.quest_id),
            true <- can_start_round?(quest, actor),
-           {:ok, event} <- Quests.Quest.handle(start_round_command, quest),
-           :ok <- PointQuest.quest_repo().write(quest, event) do
-        {:ok, event}
+           {:ok, event} <- Quests.Quest.handle(start_round_command, quest) do
+        PointQuest.quest_repo().write(quest, event)
       else
         false -> {:error, :must_be_leader_of_quest_party}
         {:error, _error} = error -> error

--- a/lib/point_quest/quests/commands/stop_round.ex
+++ b/lib/point_quest/quests/commands/stop_round.ex
@@ -37,9 +37,8 @@ defmodule PointQuest.Quests.Commands.StopRound do
                     context: %{command: stop_round_command, actor: actor} do
       with {:ok, quest} <- PointQuest.quest_repo().get_quest_by_id(stop_round_command.quest_id),
            true <- can_stop_round?(quest, actor),
-           {:ok, event} <- Quests.Quest.handle(stop_round_command, quest),
-           :ok <- PointQuest.quest_repo().write(quest, event) do
-        {:ok, event}
+           {:ok, event} <- Quests.Quest.handle(stop_round_command, quest) do
+        PointQuest.quest_repo().write(quest, event)
       else
         false -> {:error, :must_be_leader_of_quest_party}
         {:error, _error} = error -> error

--- a/lib/point_quest/quests/events/adventurer_attacked.ex
+++ b/lib/point_quest/quests/events/adventurer_attacked.ex
@@ -4,7 +4,6 @@ defmodule PointQuest.Quests.Event.AdventurerAttacked do
 
   alias PointQuest.Quests.AttackValue
 
-  @primary_key false
   embedded_schema do
     field :quest_id, :string
     field :adventurer_id, :string

--- a/lib/point_quest/quests/events/adventurer_joined_party.ex
+++ b/lib/point_quest/quests/events/adventurer_joined_party.ex
@@ -2,7 +2,6 @@ defmodule PointQuest.Quests.Event.AdventurerJoinedParty do
   use PointQuest.Valuable
   alias PointQuest.Quests.Adventurer
 
-  @primary_key false
   embedded_schema do
     field :quest_id
     field :adventurer_id

--- a/lib/point_quest/quests/events/adventurer_removed_from_party.ex
+++ b/lib/point_quest/quests/events/adventurer_removed_from_party.ex
@@ -1,7 +1,6 @@
 defmodule PointQuest.Quests.Event.AdventurerRemovedFromParty do
   use PointQuest.Valuable
 
-  @primary_key false
   embedded_schema do
     field :quest_id
     field :adventurer_id

--- a/lib/point_quest/quests/events/objective_added.ex
+++ b/lib/point_quest/quests/events/objective_added.ex
@@ -6,7 +6,6 @@ defmodule PointQuest.Quests.Event.ObjectiveAdded do
 
   alias PointQuest.Quests.Objectives.Objective
 
-  @primary_key false
   embedded_schema do
     field :quest_id, :string
     embeds_many :objectives, Objective

--- a/lib/point_quest/quests/events/objective_sorted.ex
+++ b/lib/point_quest/quests/events/objective_sorted.ex
@@ -12,7 +12,6 @@ defmodule PointQuest.Quests.Event.ObjectiveSorted do
           objectives: [Objective.t()]
         }
 
-  @primary_key false
   embedded_schema do
     field :quest_id, :string
     embeds_many :objectives, Objective

--- a/lib/point_quest/quests/events/quest_started.ex
+++ b/lib/point_quest/quests/events/quest_started.ex
@@ -21,7 +21,6 @@ defmodule PointQuest.Quests.Event.QuestStarted do
     end
   end
 
-  @primary_key false
   embedded_schema do
     field :quest_id, :string
     field :leader_id, :string

--- a/lib/point_quest/quests/events/round_ended.ex
+++ b/lib/point_quest/quests/events/round_ended.ex
@@ -6,7 +6,6 @@ defmodule PointQuest.Quests.Event.RoundEnded do
 
   alias PointQuest.Quests.Objectives.Objective
 
-  @primary_key false
   embedded_schema do
     field :quest_id, :string
     embeds_many :objectives, Objective

--- a/lib/point_quest/quests/events/round_started.ex
+++ b/lib/point_quest/quests/events/round_started.ex
@@ -6,7 +6,6 @@ defmodule PointQuest.Quests.Event.RoundStarted do
 
   alias PointQuest.Quests.Objectives.Objective
 
-  @primary_key false
   embedded_schema do
     field :quest_id, :string
     embeds_many :objectives, Objective

--- a/lib/point_quest/valuable.ex
+++ b/lib/point_quest/valuable.ex
@@ -98,7 +98,7 @@ defmodule PointQuest.Valuable do
         local_changeset =
           valuable
           |> cast(params, local_fields)
-          |> validate_required(local_fields -- unquote(optional_fields))
+          |> validate_required(local_fields -- [:id | unquote(optional_fields)])
 
         Enum.reduce(__schema__(:embeds), local_changeset, fn embed, changeset ->
           changeset

--- a/test/point_quest/quests/commands/attack_test.exs
+++ b/test/point_quest/quests/commands/attack_test.exs
@@ -88,18 +88,22 @@ defmodule PointQuest.Quests.Commands.AttackTest do
     } do
       Phoenix.PubSub.subscribe(PointQuestWeb.PubSub, quest_id)
 
-      attacked_event = %PointQuest.Quests.Event.AdventurerAttacked{
-        quest_id: quest_id,
-        adventurer_id: adventurer_id,
-        attack: 3
-      }
-
-      assert {:ok, ^attacked_event} =
+      assert {:ok,
+              %PointQuest.Quests.Event.AdventurerAttacked{
+                quest_id: ^quest_id,
+                adventurer_id: ^adventurer_id,
+                attack: 3
+              }} =
                %{quest_id: quest_id, adventurer_id: adventurer_id, attack: 3}
                |> Attack.new!()
                |> Attack.execute(adventurer_actor)
 
-      assert_receive ^attacked_event, 500
+      assert_receive %PointQuest.Quests.Event.AdventurerAttacked{
+                       quest_id: ^quest_id,
+                       adventurer_id: ^adventurer_id,
+                       attack: 3
+                     },
+                     500
     end
 
     test "succeeds if party leader is adventurer attacking", %{other_actor: actor} do


### PR DESCRIPTION
In order to make snapshots work for projecting events, we need to ensure that the events are strongly orderable.

All events should now have a primary key of id.

Valuable changed to ignore the id key on event changesets.

Commands now return {:ok, event} directly from the database call to write the event.