### PR TITLE
feat: implement quest snapshots

### DIFF
--- a/.github/workflows/elixir.yaml
+++ b/.github/workflows/elixir.yaml
@@ -90,4 +90,4 @@ jobs:
 
       # Step: Execute the tests.
       - name: Run tests
-        run: mix test
+        run: mix test --exclude couch

--- a/lib/infra/quests/couch/quest_snapshots.ex
+++ b/lib/infra/quests/couch/quest_snapshots.ex
@@ -1,0 +1,82 @@
+defmodule Infra.Quests.Couch.QuestSnapshots do
+  @moduledoc """
+  Retrieve and Store Quest Snapshots.
+  """
+  alias Infra.Couch.Client, as: CouchDB
+  alias PointQuest.Quests.Quest
+
+  @type version :: String.t()
+  @type snapshot :: %{version: version(), snapshot: Quest.t()}
+
+  @spec get_snapshot(quest_id :: String.t()) :: snapshot() | nil
+  @doc """
+  Retrieve quest snapshot at latest position or before a specified version.
+  """
+  def get_snapshot(quest_id, version \\ :latest)
+
+  @spec get_snapshot(quest_id :: String.t(), :latest | {:before, version()}) :: snapshot() | nil
+  def get_snapshot(quest_id, :latest) do
+    "/quest-snapshots-v1/_partition/quest-#{quest_id}/_all_docs"
+    |> CouchDB.get(query: [limit: 1, sorted: true, descending: true, include_docs: true])
+    |> case do
+      {:ok, %{"rows" => [snapshot]}} ->
+        %{
+          version: snapshot["id"],
+          snapshot: Ecto.embedded_load(Quest, snapshot["doc"]["snapshot"], :json)
+        }
+
+      {:ok, %{"rows" => []}} ->
+        nil
+    end
+  end
+
+  def get_snapshot(quest_id, {:before, version}) do
+    "/quest-snapshots-v1/_partition/quest-#{quest_id}/_all_docs"
+    |> CouchDB.post(%{
+      limit: 2,
+      sorted: true,
+      descending: true,
+      include_docs: true,
+      inclusive_end: false,
+      start_key: version
+    })
+    |> case do
+      {:ok, %{"rows" => [%{"id" => ^version}]}} ->
+        nil
+
+      {:ok, %{"rows" => [snapshot]}} ->
+        %{
+          version: snapshot["id"],
+          snapshot: Ecto.embedded_load(Quest, snapshot["doc"]["snapshot"], :json)
+        }
+
+      {:ok, %{"rows" => [%{"id" => ^version}, snapshot]}} ->
+        %{
+          version: snapshot["id"],
+          snapshot: Ecto.embedded_load(Quest, snapshot["doc"]["snapshot"], :json)
+        }
+
+      {:ok, %{"rows" => [snapshot | _tail]}} ->
+        %{
+          version: snapshot["id"],
+          snapshot: Ecto.embedded_load(Quest, snapshot["doc"]["snapshot"], :json)
+        }
+
+      {:ok, %{"rows" => _rows}} ->
+        nil
+    end
+  end
+
+  @spec write_snapshot(snapshot()) :: :ok
+  @doc """
+  Write a new quest snapshot at version
+  """
+  def write_snapshot(%{version: version, snapshot: %Quest{} = quest}) do
+    quest_data = Ecto.embedded_dump(quest, :json)
+
+    {:ok, _doc} =
+      CouchDB.put("/quest-snapshots-v1/#{version}", %{snapshot: quest_data})
+
+    :ok
+  end
+end

--- a/lib/point_quest/quests/commands/start_quest.ex
+++ b/lib/point_quest/quests/commands/start_quest.ex
@@ -66,7 +66,7 @@ defmodule PointQuest.Quests.Commands.StartQuest do
     end
   end
 
-  @spec execute(t()) :: PointQuest.Quests.Quest.t()
+  @spec execute(t(), keyword()) :: PointQuest.Quests.Quest.t()
   @doc """
   Executes the command to start the quest.
 
@@ -94,13 +94,14 @@ defmodule PointQuest.Quests.Commands.StartQuest do
   }}
   ```
   """
-  def execute(%__MODULE__{} = start_quest_command) do
+  def execute(%__MODULE__{} = start_quest_command, opts \\ []) do
+    repo = Keyword.get(opts, :quest_repo, PointQuest.quest_repo())
     quest = Quests.Quest.init()
 
     Telemetrex.span event: Quests.Telemetry.quest_started(),
                     context: %{command: start_quest_command} do
       with {:ok, event} <- Quests.Quest.handle(start_quest_command, quest) do
-        PointQuest.quest_repo().write(quest, event)
+        repo.write(quest, event)
       end
     after
       {:ok, event} -> %{event: event}

--- a/lib/point_quest/quests/commands/stop_round.ex
+++ b/lib/point_quest/quests/commands/stop_round.ex
@@ -22,7 +22,7 @@ defmodule PointQuest.Quests.Commands.StopRound do
     field :quest_id
   end
 
-  @spec execute(stop_round_command :: t(), actor :: Authentication.PartyLeader.t()) ::
+  @spec execute(stop_round_command :: t(), actor :: Authentication.PartyLeader.t(), keyword()) ::
           {:ok, t()}
           | {:error, Error.NotFound.exception(resource: :quest)}
           | {:error, :must_be_leader_of_quest_party}
@@ -32,13 +32,15 @@ defmodule PointQuest.Quests.Commands.StopRound do
 
   Returns the command.
   """
-  def execute(%__MODULE__{} = stop_round_command, actor) do
+  def execute(%__MODULE__{} = stop_round_command, actor, opts \\ []) do
     Telemetrex.span event: Quests.Telemetry.round_ended(),
                     context: %{command: stop_round_command, actor: actor} do
-      with {:ok, quest} <- PointQuest.quest_repo().get_quest_by_id(stop_round_command.quest_id),
+      repo = Keyword.get(opts, :quest_repo, PointQuest.quest_repo())
+
+      with {:ok, quest} <- repo.get_quest_by_id(stop_round_command.quest_id),
            true <- can_stop_round?(quest, actor),
            {:ok, event} <- Quests.Quest.handle(stop_round_command, quest) do
-        PointQuest.quest_repo().write(quest, event)
+        repo.write(quest, event)
       else
         false -> {:error, :must_be_leader_of_quest_party}
         {:error, _error} = error -> error

--- a/test/infra/quests/couch/quest_snapshots_test.exs
+++ b/test/infra/quests/couch/quest_snapshots_test.exs
@@ -1,0 +1,188 @@
+defmodule Infra.Quests.Couch.QuestSnapshotsTest do
+  use ExUnit.Case, async: true
+
+  alias PointQuest.Quests.Commands
+  alias Infra.Quests.Couch
+
+  @moduletag :couch
+
+  describe "get_snapshot/2" do
+    test "requesting latest when no snapshots exist" do
+      assert Couch.QuestSnapshots.get_snapshot("non-existent-quest", :latest) == nil
+    end
+
+    test "requesting latest when one does exist" do
+      {:ok, quest_started} =
+        Commands.StartQuest.execute(
+          Commands.StartQuest.new!(%{
+            party_leaders_adventurer: %{name: "snapper", class: "healer"}
+          }),
+          quest_repo: Couch.Db
+        )
+
+      assert {:ok, %{party: %{party_leader: party_leader}} = quest} =
+               Couch.Db.get_quest_by_id(quest_started.quest_id)
+
+      Couch.QuestSnapshots.write_snapshot(%{version: quest_started.id, snapshot: quest})
+
+      actor = PointQuest.Authentication.create_actor(party_leader)
+
+      assert %{snapshot: ^quest} =
+               Couch.QuestSnapshots.get_snapshot(quest_started.quest_id, :latest)
+
+      {:ok, add_adventurer} =
+        Commands.AddAdventurer.execute(
+          Commands.AddAdventurer.new!(%{
+            name: "new latest boi",
+            class: :healer,
+            quest_id: quest_started.quest_id
+          }),
+          quest_repo: Couch.Db
+        )
+
+      assert {:ok, quest} = Couch.Db.get_quest_by_id(quest_started.quest_id)
+      Couch.QuestSnapshots.write_snapshot(%{version: add_adventurer.id, snapshot: quest})
+
+      assert %{snapshot: ^quest} =
+               add_adventurer_snap =
+               Couch.QuestSnapshots.get_snapshot(quest_started.quest_id, :latest)
+
+      {:ok, round_started} =
+        Commands.StartRound.execute(
+          Commands.StartRound.new!(%{
+            quest_id: quest_started.quest_id
+          }),
+          actor,
+          quest_repo: Couch.Db
+        )
+
+      assert {:ok, quest} = Couch.Db.get_quest_by_id(quest_started.quest_id)
+      Couch.QuestSnapshots.write_snapshot(%{version: round_started.id, snapshot: quest})
+
+      round_started_snap = Couch.QuestSnapshots.get_snapshot(quest_started.quest_id, :latest)
+      refute round_started_snap == add_adventurer_snap
+    end
+
+    test "requesting snapshot before a version when last snapshot is that event" do
+      {:ok, quest_started} =
+        Commands.StartQuest.execute(
+          Commands.StartQuest.new!(%{
+            party_leaders_adventurer: %{name: "snapper", class: "healer"}
+          }),
+          quest_repo: Couch.Db
+        )
+
+      assert {:ok, %{party: %{party_leader: party_leader}} = quest} =
+               Couch.Db.get_quest_by_id(quest_started.quest_id)
+
+      Couch.QuestSnapshots.write_snapshot(%{version: quest_started.id, snapshot: quest})
+
+      actor = PointQuest.Authentication.create_actor(party_leader)
+
+      assert %{snapshot: ^quest} =
+               Couch.QuestSnapshots.get_snapshot(quest_started.quest_id, :latest)
+
+      {:ok, add_adventurer} =
+        Commands.AddAdventurer.execute(
+          Commands.AddAdventurer.new!(%{
+            name: "new latest boi",
+            class: :healer,
+            quest_id: quest_started.quest_id
+          }),
+          quest_repo: Couch.Db
+        )
+
+      assert {:ok, quest} = Couch.Db.get_quest_by_id(quest_started.quest_id)
+      Couch.QuestSnapshots.write_snapshot(%{version: add_adventurer.id, snapshot: quest})
+
+      assert %{snapshot: ^quest} =
+               add_adventurer_snap =
+               Couch.QuestSnapshots.get_snapshot(quest_started.quest_id, :latest)
+
+      {:ok, round_started} =
+        Commands.StartRound.execute(
+          Commands.StartRound.new!(%{
+            quest_id: quest_started.quest_id
+          }),
+          actor,
+          quest_repo: Couch.Db
+        )
+
+      assert {:ok, quest} = Couch.Db.get_quest_by_id(quest_started.quest_id)
+      Couch.QuestSnapshots.write_snapshot(%{version: round_started.id, snapshot: quest})
+
+      before_round_started_snap =
+        Couch.QuestSnapshots.get_snapshot(quest_started.quest_id, {:before, round_started.id})
+
+      assert before_round_started_snap == add_adventurer_snap
+    end
+
+    test "requesting snapshot before version when event is not last snapshot" do
+      {:ok, quest_started} =
+        Commands.StartQuest.execute(
+          Commands.StartQuest.new!(%{
+            party_leaders_adventurer: %{name: "snapper", class: "healer"}
+          }),
+          quest_repo: Couch.Db
+        )
+
+      assert {:ok, %{party: %{party_leader: party_leader}} = quest} =
+               Couch.Db.get_quest_by_id(quest_started.quest_id)
+
+      Couch.QuestSnapshots.write_snapshot(%{version: quest_started.id, snapshot: quest})
+
+      actor = PointQuest.Authentication.create_actor(party_leader)
+
+      assert %{snapshot: ^quest} =
+               Couch.QuestSnapshots.get_snapshot(quest_started.quest_id, :latest)
+
+      {:ok, add_adventurer} =
+        Commands.AddAdventurer.execute(
+          Commands.AddAdventurer.new!(%{
+            name: "new latest boi",
+            class: :healer,
+            quest_id: quest_started.quest_id
+          }),
+          quest_repo: Couch.Db
+        )
+
+      assert {:ok, quest} = Couch.Db.get_quest_by_id(quest_started.quest_id)
+      Couch.QuestSnapshots.write_snapshot(%{version: add_adventurer.id, snapshot: quest})
+
+      assert %{snapshot: ^quest} =
+               Couch.QuestSnapshots.get_snapshot(quest_started.quest_id, :latest)
+
+      {:ok, round_started} =
+        Commands.StartRound.execute(
+          Commands.StartRound.new!(%{
+            quest_id: quest_started.quest_id
+          }),
+          actor,
+          quest_repo: Couch.Db
+        )
+
+      assert {:ok, quest} = Couch.Db.get_quest_by_id(quest_started.quest_id)
+      Couch.QuestSnapshots.write_snapshot(%{version: round_started.id, snapshot: quest})
+
+      latest_snapshot = Couch.QuestSnapshots.get_snapshot(quest_started.quest_id, :latest)
+
+      {:ok, add_adventurer_new} =
+        Commands.AddAdventurer.execute(
+          Commands.AddAdventurer.new!(%{
+            name: "newer latest boi",
+            class: :healer,
+            quest_id: quest_started.quest_id
+          }),
+          quest_repo: Couch.Db
+        )
+
+      before_last_event =
+        Couch.QuestSnapshots.get_snapshot(
+          quest_started.quest_id,
+          {:before, add_adventurer_new.id}
+        )
+
+      assert before_last_event == latest_snapshot
+    end
+  end
+end


### PR DESCRIPTION
Utilize couch's start_key and descending sorting to allow retrieving of snapshots including finding the most recent snapshot before an event. Add some tests thoroughly proving the logic in this convoluted case statement.

Extend some of the command functions for testability to allow injecting the underlying repo dependency to allow for testing Couch via these unit tests when the other tests are utilizing the in-memory DB for unit testing.