### PR TITLE
Refactor CouchDB namespace

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -101,7 +101,7 @@ if config_env() == :prod do
   # See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.
 end
 
-config :point_quest, Infra.Couch.Client,
+config :point_quest, CouchDB.Client,
   base_url: System.get_env("COUCH_URL"),
   username: System.get_env("COUCH_USER"),
   password: System.get_env("COUCH_PASS")

--- a/lib/infra/couchdb.ex
+++ b/lib/infra/couchdb.ex
@@ -1,0 +1,19 @@
+defmodule CouchDB do
+  def get(url, opts \\ []) do
+    CouchDB.Client.get(url, opts)
+  end
+
+  def put(url, doc, opts \\ []) do
+    CouchDB.Client.put(url, doc, opts)
+  end
+
+  def post(url, doc, opts \\ []) do
+    CouchDB.Client.post(url, doc, opts)
+  end
+
+  def paginate_view(view, page_opts, opts \\ []) do
+    view
+    |> CouchDB.Client.paginate_view(page_opts, opts)
+    |> Stream.map(&CouchDB.Document.from_doc(&1["doc"]))
+  end
+end

--- a/lib/infra/couchdb/client.ex
+++ b/lib/infra/couchdb/client.ex
@@ -1,6 +1,4 @@
-defmodule Infra.Couch.Client do
-  alias Infra.Couch
-
+defmodule CouchDB.Client do
   @type page_opts :: %{
           end_key: String.t() | nil,
           limit: non_neg_integer() | nil,
@@ -16,13 +14,13 @@ defmodule Infra.Couch.Client do
     |> Tesla.put(url, doc, opts)
     |> case do
       {:ok, %{status: 400, body: %{"reason" => reason}}} ->
-        {:error, Couch.BadRequest.exception(reason)}
+        {:error, CouchDB.BadRequest.exception(reason)}
 
       {:ok, %{status: 401, body: %{"reason" => reason}}} ->
-        {:error, Couch.Unauthorized.exception(reason)}
+        {:error, CouchDB.Unauthorized.exception(reason)}
 
       {:ok, %{status: 412, body: %{"reason" => reason}}} ->
-        {:error, Couch.PreconditionFailed.exception(reason)}
+        {:error, CouchDB.PreconditionFailed.exception(reason)}
 
       {:ok, %{body: body}} ->
         {:ok, body}
@@ -34,13 +32,13 @@ defmodule Infra.Couch.Client do
     |> Tesla.post(url, doc, opts)
     |> case do
       {:ok, %{status: 400, body: %{"reason" => reason}}} ->
-        {:error, Couch.BadRequest.exception(reason)}
+        {:error, CouchDB.BadRequest.exception(reason)}
 
       {:ok, %{status: 401, body: %{"reason" => reason}}} ->
-        {:error, Couch.Unauthorized.exception(reason)}
+        {:error, CouchDB.Unauthorized.exception(reason)}
 
       {:ok, %{status: 412, body: %{"reason" => reason}}} ->
-        {:error, Couch.PreconditionFailed.exception(reason)}
+        {:error, CouchDB.PreconditionFailed.exception(reason)}
 
       {:ok, %{body: body}} ->
         {:ok, body}
@@ -52,13 +50,13 @@ defmodule Infra.Couch.Client do
     |> Tesla.get(url, opts)
     |> case do
       {:ok, %{status: 400, body: %{"reason" => reason}}} ->
-        {:error, Couch.BadRequest.exception(reason)}
+        {:error, CouchDB.BadRequest.exception(reason)}
 
       {:ok, %{status: 401, body: %{"reason" => reason}}} ->
-        {:error, Couch.Unauthorized.exception(reason)}
+        {:error, CouchDB.Unauthorized.exception(reason)}
 
       {:ok, %{status: 404, body: %{"reason" => reason}}} ->
-        {:error, Couch.NotFound.exception(reason)}
+        {:error, CouchDB.NotFound.exception(reason)}
 
       {:ok, %{body: body}} ->
         {:ok, body}
@@ -84,8 +82,6 @@ defmodule Infra.Couch.Client do
             page_opts =
               page_opts
               |> Map.put(:start_key, List.last(rows)["id"] <> "\ufff0")
-
-            rows = Enum.map(rows, &Couch.Document.from_doc(&1["doc"]))
 
             {rows, page_opts}
 

--- a/lib/infra/couchdb/document.ex
+++ b/lib/infra/couchdb/document.ex
@@ -1,4 +1,4 @@
-defmodule Infra.Couch.Document do
+defmodule CouchDB.Document do
   @moduledoc """
   Utilities for working with CouchDB documents.
   """

--- a/lib/infra/couchdb/exception.ex
+++ b/lib/infra/couchdb/exception.ex
@@ -1,4 +1,4 @@
-defmodule Infra.Couch.DocumentConflict do
+defmodule CouchDB.DocumentConflict do
   defexception [:document_id, :message]
 
   def exception(opts) do
@@ -9,18 +9,18 @@ defmodule Infra.Couch.DocumentConflict do
   end
 end
 
-defmodule Infra.Couch.Unauthorized do
+defmodule CouchDB.Unauthorized do
   defexception [:message]
 end
 
-defmodule Infra.Couch.NotFound do
+defmodule CouchDB.NotFound do
   defexception [:message]
 end
 
-defmodule Infra.Couch.BadRequest do
+defmodule CouchDB.BadRequest do
   defexception [:message]
 end
 
-defmodule Infra.Couch.PreconditionFailed do
+defmodule CouchDB.PreconditionFailed do
   defexception [:message]
 end

--- a/lib/infra/quests/couch/db.ex
+++ b/lib/infra/quests/couch/db.ex
@@ -4,15 +4,14 @@ defmodule Infra.Quests.Couch.Db do
   alias PointQuest.Error
   alias PointQuest.Quests.Event
 
-  alias Infra.Couch
   alias Infra.Quests.Couch, as: QuestCouch
 
   @impl PointQuest.Behaviour.Quests.Repo
   def write(_init_quest, %Event.QuestStarted{} = event) do
     with {:ok, doc} <-
-           Couch.Client.put(
+           CouchDB.put(
              "/events-v2/quest-#{event.quest_id}:#{ExULID.ULID.generate()}",
-             Couch.Document.to_doc(event)
+             CouchDB.Document.to_doc(event)
            ),
          {:ok, pid} <-
            Horde.DynamicSupervisor.start_child(

--- a/lib/infra/quests/couch/quest_snapshots.ex
+++ b/lib/infra/quests/couch/quest_snapshots.ex
@@ -2,7 +2,6 @@ defmodule Infra.Quests.Couch.QuestSnapshots do
   @moduledoc """
   Retrieve and Store Quest Snapshots.
   """
-  alias Infra.Couch.Client, as: CouchDB
   alias PointQuest.Quests.Quest
 
   @type version :: String.t()


### PR DESCRIPTION
The previous `Infra.Couch` namespace was running into a lot of naming conflicts when using it in the `Infra.Quests.Couch` namespace. This refactor moves to a toplevel `CouchDB` namespace. Further work will separate event more PointQuest logic from the `CouchDB` namespace.

Closes: PQ-159