### PR TITLE
Add events stream to nerd bar

### DIFF
--- a/lib/point_quest/quests/events/adventurer_attacked.ex
+++ b/lib/point_quest/quests/events/adventurer_attacked.ex
@@ -7,7 +7,7 @@ defmodule PointQuest.Quests.Event.AdventurerAttacked do
   embedded_schema do
     field :quest_id, :string
     field :adventurer_id, :string
-    field :attack, AttackValue
+    field :attack, AttackValue, redact: true
   end
 
   def new!(params) do


### PR DESCRIPTION
This creates a liveview stream in the nerd bar which prepends the newest event to the top. This will come in handy during demos.

Closes: PQ-164

![image](https://github.com/user-attachments/assets/0f6d77cb-f0e4-4004-8c77-771a1db5f271)
