### PR TITLE
persist display of quest objective

### DIFF
--- a/lib/point_quest/quests/quest.ex
+++ b/lib/point_quest/quests/quest.ex
@@ -125,11 +125,23 @@ defmodule PointQuest.Quests.Quest do
   end
 
   def project(%Event.RoundStarted{objectives: objectives}, %__MODULE__{} = quest) do
+    quest_objective =
+      objectives
+      |> Enum.find(&(&1.status == :current))
+      |> case do
+        nil ->
+          ""
+
+        objective ->
+          objective.title
+      end
+
     %__MODULE__{
       quest
       | round_active?: true,
         attacks: [],
-        objectives: objectives
+        objectives: objectives,
+        quest_objective: quest_objective
     }
   end
 

--- a/lib/point_quest_web/live/quest.ex
+++ b/lib/point_quest_web/live/quest.ex
@@ -18,6 +18,7 @@ defmodule PointQuestWeb.QuestLive do
   def render(assigns) do
     ~H"""
     <div id="top-level-wrapper" class="w-full flex mb-5">
+      <!-- Objective sidebar -->
       <div :if={is_party_leader?(@actor)} id="objectives" class="w-1/5 mr-5">
         <div class="pb-5 w-full">
           <div id="sortable-list" phx-hook="Sortable" class="shadow-sm">
@@ -69,6 +70,7 @@ defmodule PointQuestWeb.QuestLive do
           </div>
         </div>
       </div>
+      <!-- Objective sidebar end -->
       <div id="quest-view" class="w-4/5">
         <div class="flex flex-col gap-y-8">
           <.render_party_leader_controls
@@ -77,7 +79,7 @@ defmodule PointQuestWeb.QuestLive do
             quest_objective={@quest_objective}
           />
           <div class="flex justify-between">
-            <div class={"#{if @round_active?, do: "visible", else: "invisible"} flex gap-x-2 items-center"}>
+            <div class="flex gap-x-2 items-center">
               <.icon name="hero-arrow-top-right-on-square" />
               <a href={@quest_objective} target="_blank" class="text-indigo-500">
                 <%= @quest_objective %>

--- a/mix.exs
+++ b/mix.exs
@@ -68,8 +68,7 @@ defmodule PointQuest.MixProject do
       {:telemetrex, "~> 0.2"},
       {:telemetry_metrics, "~> 0.6"},
       {:telemetry_poller, "~> 1.0"},
-      {:tesla, "~> 1.7"},
-      {:timex, "~> 3.7"}
+      {:tesla, "~> 1.7"}
     ]
   end
 

--- a/test/point_quest/quests/quest_test.exs
+++ b/test/point_quest/quests/quest_test.exs
@@ -118,10 +118,20 @@ defmodule PointQuest.Quests.QuestTest do
       assert Enum.member?(attacks, %Quests.Attack{adventurer_id: adventurer_id, attack: 5})
     end
 
-    test "projects RoundStarted event", %{
+    test "projects RoundStarted event with current objective", %{
       quest: %{id: quest_id} = quest,
       party_leader_actor: actor
     } do
+      {:ok, objective_event} =
+        %{quest_id: quest_id, quest_objective: "this is a test"}
+        |> Quests.Commands.AddSimpleObjective.new!()
+        |> Quests.Commands.AddSimpleObjective.execute(actor)
+
+      assert %Quests.Quest{
+               id: ^quest_id,
+               objectives: [%{title: "this is a test"}]
+             } = quest = Quests.Quest.project(objective_event, quest)
+
       {:ok, event} =
         %{quest_id: quest_id}
         |> Quests.Commands.StartRound.new!()
@@ -129,7 +139,8 @@ defmodule PointQuest.Quests.QuestTest do
 
       assert %Quests.Quest{
                id: ^quest_id,
-               round_active?: true
+               round_active?: true,
+               quest_objective: "this is a test"
              } = Quests.Quest.project(event, quest)
     end
 


### PR DESCRIPTION
Set the quest objective when a round starts in the quest_objective property for a quest, and also don't make the objective invisible if the round is not active.

Also removed Timex as it was an unused dependency.